### PR TITLE
reject bad http status codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ function adapter() {
       var response = (handler[1] instanceof Function)
         ? handler[1](config)
         : handler.slice(1);
-      resolve({
+	  ((response[0] === 1223) || (response[0] >= 200 && response[0] < 300 ) ? resolve : reject) 
+      ({
         status: response[0],
         data: response[1],
         headers: response[2],

--- a/test/mock_adapter_test.js
+++ b/test/mock_adapter_test.js
@@ -126,6 +126,20 @@ describe('MockAdapter', function() {
       });
   });
 
+  it('rejects when the status is >= 300', function(done) {
+	mock.onGet('/moo').reply(500);
+
+	instance.get('/moo')
+      .then(
+	    function(response) {
+	    },
+	    function(response) {
+          expect(response.status).to.equal(500);
+          done();
+	    }
+	  );
+  });
+
   context('on the default instance', function() {
     afterEach(function() {
       axios.defaults.adapter = undefined;


### PR DESCRIPTION
If i return a status code like 401 from my mocked service, i'd expect the call to axios to be rejected, as it is in both the http and the xhr adapter. Agreed?

Test is ugly because there are no spies in mocha and i didnt wanna add a dependency. hope that's still okeydokey