### PR TITLE
GET vs get - Accept method in any case when passing the relevant config to axios.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var verbs = ['get', 'post', 'head', 'delete', 'patch', 'put'];
 
 function findHandler(matchers, method, url) {
-  return matchers[method].find(function(matcher) {
+  return matchers[method.toLowerCase()].find(function(matcher) {
     if (typeof matcher[0] === 'string') {
       return url === matcher[0];
     } else if (matcher[0] instanceof RegExp) {

--- a/test/mock_adapter_test.js
+++ b/test/mock_adapter_test.js
@@ -201,6 +201,21 @@ describe('MockAdapter', function() {
           done();
         });
     });
+
+    it('mocks requests on the default instance when method CAPS', function(done) {
+      var defaultMock = new MockAdapter(axios);
+
+      defaultMock.onGet('/foo').reply(200);
+
+      axios({
+        method: 'GET',
+        url: '/foo'
+      })
+        .then(function(response) {
+          expect(response.status).to.equal(200);
+          done();
+        });
+    });
   });
 
   context('.onAny', function() {


### PR DESCRIPTION
I was getting `TypeError: Cannot read property 'find' of undefined` because my method was all caps.