### PR TITLE
Updating to axios@0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,11 @@
     "url": "https://github.com/ctimmerm/axios-mock-adapter/issues"
   },
   "homepage": "https://github.com/ctimmerm/axios-mock-adapter#readme",
+  "peerDependencies": {
+    "axios": ">= 0.13.0"
+  },
   "devDependencies": {
-    "axios": "^0.12.0",
+    "axios": "^0.13.0",
     "chai": "^3.5.0",
     "eslint": "^2.13.1",
     "mocha": "^2.4.5",

--- a/src/index.js
+++ b/src/index.js
@@ -5,28 +5,30 @@ var utils = require('./utils');
 var verbs = ['get', 'post', 'head', 'delete', 'patch', 'put'];
 
 function adapter() {
-  return function(resolve, reject, config) {
-    var url = config.url.slice(config.baseURL ? config.baseURL.length : 0);
-    var handler = utils.findHandler(this.handlers, config.method, url);
+  return function(config) {
+    return new Promise(function(resolve, reject) {
+      var url = config.url.slice(config.baseURL ? config.baseURL.length : 0);
+      var handler = utils.findHandler(this.handlers, config.method, url);
 
-    if (handler) {
-      utils.purgeIfReplyOnce(this, handler);
-      var response = handler[1] instanceof Function
-        ? handler[1](config)
-        : handler.slice(1);
+      if (handler) {
+        utils.purgeIfReplyOnce(this, handler);
+        var response = handler[1] instanceof Function
+          ? handler[1](config)
+          : handler.slice(1);
 
-      utils.settle(resolve, reject, {
-        status: response[0],
-        data: response[1],
-        headers: response[2],
-        config: config
-      }, this.delayResponse);
-    } else {
-      utils.settle(resolve, reject, {
-        status: 404,
-        config: config
-      }, this.delayResponse);
-    }
+        utils.settle(resolve, reject, {
+          status: response[0],
+          data: response[1],
+          headers: response[2],
+          config: config
+        }, this.delayResponse);
+      } else {
+        utils.settle(resolve, reject, {
+          status: 404,
+          config: config
+        }, this.delayResponse);
+      }
+    }.bind(this));
   }.bind(this);
 }
 


### PR DESCRIPTION
There are breaking changes in `axios@0.13.0` related to request adapters. This PR addresses those changes. For further details see [Upgrade Guide](https://github.com/mzabriskie/axios/blob/master/UPGRADE_GUIDE.md#012x---0130).