### PR TITLE
added request body/data matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,10 @@ mock.onAny(/.*/).reply(config => {
   return [500, {}];
 });
 ```
+
+Mocking a request with a specific request body
+
+```js
+// usable with reply, replyOnce, onAny, onPatch, onPost, onPost ...
+mock.onPut('/withBody', { request: 'body' }).reply(200);
+```

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ mock.onAny(/.*/).reply(config => {
 });
 ```
 
-Mocking a request with a specific request body
+Mocking a request with a specific request body/data
 
 ```js
-// usable with reply, replyOnce, onAny, onPatch, onPost, onPost ...
+// usable with reply, replyOnce, onAny, onPatch, onPost, onPut ...
 mock.onPut('/withBody', { request: 'body' }).reply(200);
 ```

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "mocha": "^2.4.5",
     "rimraf": "^2.5.2",
     "webpack": "^1.12.15"
+  },
+  "dependencies": {
+    "deep-eql": "^0.1.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ function adapter() {
   return function(config) {
     return new Promise(function(resolve, reject) {
       var url = config.url.slice(config.baseURL ? config.baseURL.length : 0);
-      var handler = utils.findHandler(this.handlers, config.method, url);
+      var handler = utils.findHandler(this.handlers, config.method, url, config.data);
 
       if (handler) {
         utils.purgeIfReplyOnce(this, handler);
@@ -63,11 +63,11 @@ MockAdapter.prototype.restore = function restore() {
 
 MockAdapter.prototype.reset = reset;
 
-MockAdapter.prototype.onAny = function onAny(matcher) {
+MockAdapter.prototype.onAny = function onAny(matcher, body) {
   var _this = this;
   return {
     reply: function reply(code, response, headers) {
-      var handler = [matcher, code, response, headers];
+      var handler = [matcher, code, response, headers, body];
       verbs.forEach(function(verb) {
         _this.handlers[verb].push(handler);
       });
@@ -75,7 +75,7 @@ MockAdapter.prototype.onAny = function onAny(matcher) {
     },
 
     replyOnce: function replyOnce(code, response, headers) {
-      var handler = [matcher, code, response, headers];
+      var handler = [matcher, code, response, headers, body];
       _this.replyOnceHandlers.push(handler);
       verbs.forEach(function(verb) {
         _this.handlers[verb].push(handler);
@@ -87,17 +87,17 @@ MockAdapter.prototype.onAny = function onAny(matcher) {
 
 verbs.forEach(function(method) {
   var methodName = 'on' + method.charAt(0).toUpperCase() + method.slice(1);
-  MockAdapter.prototype[methodName] = function(matcher) {
+  MockAdapter.prototype[methodName] = function(matcher, body) {
     var _this = this;
     return {
       reply: function reply(code, response, headers) {
-        var handler = [matcher, code, response, headers];
+        var handler = [matcher, code, response, headers, body];
         _this.handlers[method].push(handler);
         return _this;
       },
 
       replyOnce: function replyOnce(code, response, headers) {
-        var handler = [matcher, code, response, headers];
+        var handler = [matcher, code, response, headers, body];
         _this.handlers[method].push(handler);
         _this.replyOnceHandlers.push(handler);
         return _this;

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,14 +8,19 @@ function find(array, predicate) {
   }
 }
 
-function findHandler(handlers, method, url) {
+function findHandler(handlers, method, url, body) {
   return find(handlers[method.toLowerCase()], function(handler) {
     if (typeof handler[0] === 'string') {
-      return url === handler[0];
+      return url === handler[0] && isBodyMatching(body, handler[4]);
     } else if (handler[0] instanceof RegExp) {
-      return handler[0].test(url);
+      return handler[0].test(url) && isBodyMatching(body, handler[4]);
     }
   });
+}
+
+function isBodyMatching(body, requiredBody) {
+  return requiredBody === undefined
+    || (typeof body === 'string' && body === requiredBody || body === JSON.stringify(requiredBody));
 }
 
 function purgeIfReplyOnce(mock, handler) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,16 +20,14 @@ function findHandler(handlers, method, url, body) {
 }
 
 function isBodyMatching(body, requiredBody) {
+  if (requiredBody === undefined) {
+    return true;
+  }
   var parsedBody;
-  var isJSON = true;
   try {
     parsedBody = JSON.parse(body);
-  } catch (error) {
-    isJSON = false;
-  }
-  return requiredBody === undefined
-    || (typeof body === 'string' && body === requiredBody || eql(body, requiredBody)
-    || (isJSON && eql(parsedBody, requiredBody)));
+  } catch (e) { }
+  return parsedBody ? eql(parsedBody, requiredBody) : eql(body, requiredBody);
 }
 
 function purgeIfReplyOnce(mock, handler) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 'use strict';
+var eql = require('deep-eql');
 
 function find(array, predicate) {
   var length = array.length;
@@ -19,8 +20,16 @@ function findHandler(handlers, method, url, body) {
 }
 
 function isBodyMatching(body, requiredBody) {
+  var parsedBody;
+  var isJSON = true;
+  try {
+    parsedBody = JSON.parse(body);
+  } catch (error) {
+    isJSON = false;
+  }
   return requiredBody === undefined
-    || (typeof body === 'string' && body === requiredBody || body === JSON.stringify(requiredBody));
+    || (typeof body === 'string' && body === requiredBody || eql(body, requiredBody)
+    || (isJSON && eql(parsedBody, requiredBody)));
 }
 
 function purgeIfReplyOnce(mock, handler) {

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -122,7 +122,7 @@ describe('MockAdapter basics', function() {
     });
   });
 
-  it('does not match when its wrong body', function(done) {
+  it('does not match when body is wrong', function(done) {
     var body = { body: { is: 'passed' }, in: true };
     mock.onPatch('/wrongObjBody', body).reply(200);
 
@@ -132,11 +132,20 @@ describe('MockAdapter basics', function() {
     });
   });
 
-  it('does not match when its wrong body with string body', function(done) {
+  it('does not match when string body is wrong', function(done) {
     mock.onPatch('/wrongStrBody', 'foo').reply(200);
 
     instance.patch('/wrongStrBody', 'bar').catch(function(response) {
       expect(response.status).to.equal(404);
+      done();
+    });
+  });
+
+  it('does match with string body', function(done) {
+    mock.onPatch(/^\/strBody$/, 'foo').reply(200);
+
+    instance.patch('/strBody', 'foo').then(function(response) {
+      expect(response.status).to.equal(200);
       done();
     });
   });

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -34,6 +34,19 @@ describe('MockAdapter basics', function() {
     expect(mock.handlers['get'][0][3].baz).to.equal('quux');
   });
 
+  it('registers the mock handlers with body on the mock instance', function() {
+    var body = { foo: 'bar' };
+    var response = { foo: 'bar' };
+    var headers = { baz: 'quux' };
+    mock.onGet('/foo', body).reply(200, response, headers);
+
+    expect(mock.handlers['get'][0][0]).to.equal('/foo');
+    expect(mock.handlers['get'][0][1]).to.equal(200);
+    expect(mock.handlers['get'][0][2]).to.eql(response);
+    expect(mock.handlers['get'][0][3]).to.equal(headers);
+    expect(mock.handlers['get'][0][4]).to.eql(body);
+  });
+
   it('mocks requests', function(done) {
     mock.onGet('/foo').reply(200, {
       foo: 'bar'
@@ -97,6 +110,35 @@ describe('MockAdapter basics', function() {
       .then(function() {
         done();
       });
+  });
+
+  it('can pass a body to match to a handler', function(done) {
+    var body = { body: { is: 'passed' }, in: true };
+    mock.onPost('/withBody', body).reply(200);
+
+    instance.post('/withBody', body).then(function(response) {
+      expect(response.status).to.equal(200);
+      done();
+    });
+  });
+
+  it('does not match when its wrong body', function(done) {
+    var body = { body: { is: 'passed' }, in: true };
+    mock.onPatch('/wrongObjBody', body).reply(200);
+
+    instance.patch('/wrongObjBody', { wrong: 'body' }).catch(function(response) {
+      expect(response.status).to.equal(404);
+      done();
+    });
+  });
+
+  it('does not match when its wrong body with string body', function(done) {
+    mock.onPatch('/wrongStrBody', 'foo').reply(200);
+
+    instance.patch('/wrongStrBody', 'bar').catch(function(response) {
+      expect(response.status).to.equal(404);
+      done();
+    });
   });
 
   it('passes the config to the callback', function(done) {

--- a/test/on_any.spec.js
+++ b/test/on_any.spec.js
@@ -32,6 +32,19 @@ describe('MockAdapter onAny', function() {
       });
   });
 
+  it('mocks any request with a matching url and body', function(done) {
+    var body = [{ object: { with: { deep: 'property' } }, array: ['1', 'abc'] }, 'a'];
+    mock.onAny('/anyWithBody', body).reply(200);
+
+    instance.put('/anyWithBody', body)
+      .then(function() {
+        return instance.post('/anyWithBody', body);
+      })
+      .then(function() {
+        done();
+      });
+  });
+
   it('removes all handlers after replying with replyOnce', function(done) {
     mock.onAny('/foo').replyOnce(200);
 

--- a/test/reply_once.spec.js
+++ b/test/reply_once.spec.js
@@ -66,4 +66,21 @@ describe('MockAdapter replyOnce', function() {
         done();
       });
   });
+
+  it('replies only once when using request body matching', function(done) {
+    var called = false;
+    var body = 'abc';
+    mock.onPost('/onceWithBody', body).replyOnce(200);
+
+    instance.post('/onceWithBody', body)
+      .then(function() {
+        called = true;
+        return instance.post('/onceWithBody', body);
+      })
+      .catch(function(response) {
+        expect(called).to.be.true;
+        expect(response.status).to.equal(404);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
fixes #10 
I used JSON.stringify for comparison, since the request body/data in the axios request config is a JSON string anyway, so no dependency added.
Since I didn't add filtering to only allow post/put/patch for this other types (get etc) will not match a request handler with a body.

All tests and linting are green on my machine.