### PR TITLE
Implement passThrough and reply() with Promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "mocha",
     "lint": "eslint src test",
     "build:umd": "webpack src/index.js dist/axios-mock-adapter.js",
-    "build:umd:min": "NODE_ENV=production webpack src/index.js dist/axios-mock-adapter.min.js",
+    "build:umd:min": "set NODE_ENV=production&& webpack src/index.js dist/axios-mock-adapter.min.js",
     "prepublish": "npm run clean && npm run build:umd && npm run build:umd:min"
   },
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ function MockAdapter(axiosInstance, options) {
     this.delayResponse = options && options.delayResponse > 0
       ? options.delayResponse
       : null;
+    this.passThrough = options && options.passThrough;
     axiosInstance.defaults.adapter = adapter.call(this);
   }
 }

--- a/test/pass_through.spec.js
+++ b/test/pass_through.spec.js
@@ -1,0 +1,80 @@
+var axios = require('axios');
+var expect = require('chai').expect;
+var createServer = require('http').createServer;
+
+var MockAdapter = require('../src');
+
+describe('MockAdapter(passThrough=true) tests (requires Node)', function() {
+  var instance;
+  var mock;
+  var httpServer;
+  var serverUrl;
+
+  before('set up Node server', function() {
+    return new Promise(function(resolve, reject) {
+      httpServer = createServer(function(req, resp) {
+        if (req.url === '/error') {
+          resp.statusCode = 500;
+          resp.end();
+        } else {
+          resp.statusCode = 200;
+          // Reply with path minus leading /
+          resp.end(req.url.slice(1), 'utf8');
+        }
+      })
+      .listen(0, 'localhost', function() {
+        serverUrl = 'http://localhost:' + httpServer.address().port;
+        resolve();
+      })
+      .on('error', reject);
+    });
+  });
+
+  beforeEach(function() {
+    instance = axios.create({ baseURL: serverUrl });
+    mock = new MockAdapter(instance, { passThrough: true });
+  });
+
+  it('allows normal mocking', function() {
+    mock.onGet('/foo').reply(200, 'bar');
+
+    return instance.get('/foo')
+      .then(function(response) {
+        expect(response.status).to.equal(200);
+        expect(response.data).to.equal('bar');
+      });
+  });
+
+  it('allows selective mocking', function() {
+    mock.onGet('/foo').reply(200, 'bar');
+    mock.onGet('/notFound').reply(200, 'found');
+
+    return Promise.all([
+      instance.get('/foo')
+        .then(function(response) {
+          expect(response.status).to.equal(200);
+          expect(response.data).to.equal('bar');
+        }),
+      instance.get('/notFound')
+        .then(function(response) {
+          expect(response.status).to.equal(200);
+          expect(response.data).to.equal('found');
+        }),
+      instance.get('/bar')
+        .then(function(response) {
+          expect(response.status).to.equal(200);
+          expect(response.data).to.equal('bar');
+        })
+    ]);
+  });
+
+  it('handles errors correctly', function() {
+    return instance.get('/error')
+      .then(function(response) {
+        expect(false).to.equal(true);
+      })
+      .catch(function(error) {
+        expect(error).to.have.deep.property('response.status', 500);
+      });
+  });
+});

--- a/test/promise.spec.js
+++ b/test/promise.spec.js
@@ -1,0 +1,73 @@
+var axios = require('axios');
+var expect = require('chai').expect;
+
+var MockAdapter = require('../src');
+
+describe('MockAdapter reply with Promise', function() {
+  var instance;
+  var mock;
+
+  beforeEach(function() {
+    instance = axios.create();
+    mock = new MockAdapter(instance);
+  });
+
+  it('allows resolving with Promise', function() {
+    mock
+      .onGet('/promise')
+      .reply(function() {
+        return new Promise(function(resolve, reject) {
+          resolve([200, { bar: 'fooPromised' }]);
+        });
+      });
+
+    return instance
+      .get('/promise')
+      .then(function(response) {
+        expect(response.status).to.equal(200);
+        expect(response.data.bar).to.equal('fooPromised');
+      })
+      .catch(function() {
+        expect(true).to.equal(false);
+      });
+  });
+
+  it('rejects after Promise resolves to error response', function() {
+    mock
+      .onGet('/bad/promise')
+      .reply(function() {
+        return new Promise(function(resolve, reject) {
+          resolve([400, { bad: 'request' }]);
+        });
+      });
+
+    return instance
+      .get('/bad/promise')
+      .then(function(response) {
+        expect(true).to.equal(false);
+      })
+      .catch(function(error) {
+        expect(error).to.have.deep.property('response.status', 400);
+        expect(error).to.have.deep.property('response.data.bad', 'request');
+      });
+  });
+
+  it('passes rejecting Promise verbatim', function() {
+    mock
+      .onGet('/reject')
+      .reply(function() {
+        return new Promise(function(resolve, reject) {
+          reject({ custom: 'error' });
+        });
+      });
+
+    return instance
+      .get('/reject')
+      .then(function(response) {
+        expect(true).to.equal(false);
+      })
+      .catch(function(error) {
+        expect(error).to.deep.equal({ custom: 'error' });
+      });
+  });
+});


### PR DESCRIPTION
Resolves #19 and #20: 
 * Use `passThrough: true` to route non-mocked endpoints back to Axios
 * Add support for `.reply(function)` itself returning a Promise

I put a note in README.md that support for replying with a Promise will come out in version 1.7.0. Please edit if next version is not that.