### PR TITLE
passThrough refactoring

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -18,10 +18,15 @@ function handleRequest(mockAdapter, resolve, reject, config) {
   if (handler) {
     utils.purgeIfReplyOnce(mockAdapter, handler);
 
-    if (!(handler[1] instanceof Function)) {
-      utils.settle(resolve, reject, makeResponse(handler.slice(1), config), mockAdapter.delayResponse);
+    if (handler.length === 2) { // passThrough handler
+      mockAdapter
+        .axiosInstance
+        .request(config)
+        .then(resolve, reject);
+    } else if (!(handler[2] instanceof Function)) {
+      utils.settle(resolve, reject, makeResponse(handler.slice(2), config), mockAdapter.delayResponse);
     } else {
-      var result = handler[1](config);
+      var result = handler[2](config);
       if (!(result.then instanceof Function)) {
         utils.settle(resolve, reject, makeResponse(result, config), mockAdapter.delayResponse);
       } else {
@@ -42,17 +47,10 @@ function handleRequest(mockAdapter, resolve, reject, config) {
       }
     }
   } else { // handler not found
-    if (!mockAdapter.passThrough) {
-      utils.settle(resolve, reject, {
-        status: 404,
-        config: config
-      }, mockAdapter.delayResponse);
-    } else {
-      mockAdapter
-        .axiosInstance
-        .request(config)
-        .then(resolve, reject);
-    }
+    utils.settle(resolve, reject, {
+      status: 404,
+      config: config
+    }, mockAdapter.delayResponse);
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,6 @@ function MockAdapter(axiosInstance, options) {
     this.delayResponse = options && options.delayResponse > 0
       ? options.delayResponse
       : null;
-    this.passThrough = options && options.passThrough;
     axiosInstance.defaults.adapter = adapter.call(this);
   }
 }
@@ -55,17 +54,24 @@ VERBS.concat('any').forEach(function(method) {
   var methodName = 'on' + method.charAt(0).toUpperCase() + method.slice(1);
   MockAdapter.prototype[methodName] = function(matcher, body) {
     var _this = this;
+    var matcher = matcher === undefined ?  /.*/ : matcher;
     return {
       reply: function reply(code, response, headers) {
-        var handler = [matcher, code, response, headers, body];
+        var handler = [matcher, body, code, response, headers];
         addHandler(method, _this.handlers, handler);
         return _this;
       },
 
       replyOnce: function replyOnce(code, response, headers) {
-        var handler = [matcher, code, response, headers, body];
+        var handler = [matcher, body, code, response, headers];
         addHandler(method, _this.handlers, handler);
         _this.replyOnceHandlers.push(handler);
+        return _this;
+      },
+
+      passThrough: function passThrough() {
+        var handler = [matcher, body];
+        addHandler(method, _this.handlers, handler);
         return _this;
       }
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,9 +21,9 @@ function find(array, predicate) {
 function findHandler(handlers, method, url, body) {
   return find(handlers[method.toLowerCase()], function(handler) {
     if (typeof handler[0] === 'string') {
-      return url === handler[0] && isBodyMatching(body, handler[4]);
+      return url === handler[0] && isBodyMatching(body, handler[1]);
     } else if (handler[0] instanceof RegExp) {
-      return handler[0].test(url) && isBodyMatching(body, handler[4]);
+      return handler[0].test(url) && isBodyMatching(body, handler[1]);
     }
   });
 }


### PR DESCRIPTION
As discussed in #21, a more suitable approach for the `passThrough` behaviour is to implement it as a specific kind of handler. This PR does that, and also adds support for matching all paths (i.e. `/.*/`) when no path is specified.

Note: I needed to change the format of the internal handler specification. This caused two tests in the "basic" set to fail. Since the internal formats are anyway not part of the documented API, I thought better to just remove those tests as the functionality is anyway covered by other tests.