### PR TITLE
report url in the error message

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -61,12 +61,14 @@ function settle(resolve, reject, response, delay) {
     return;
   }
 
-  if (response.config && response.config.validateStatus) {
-    response.config.validateStatus(response.status)
+  var config = response.config;
+
+  if (config && config.validateStatus) {
+    config.validateStatus(response.status)
       ? resolve(response)
       : reject(createErrorResponse(
-        'Request failed with status code ' + response.status,
-        response.config,
+        'Request ' + config.method.toUpperCase() + ' ' + config.url + ' failed with status code ' + response.status,
+        config,
         response
       ));
     return;

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -206,7 +206,7 @@ describe('MockAdapter basics', function() {
     return instance.get('/foo')
       .catch(function(error) {
         expect(error).to.be.an.instanceof(Error);
-        expect(error.message).to.match(/request failed/i);
+        expect(error.message).to.match(/request GET \/foo failed/i);
       });
   });
 


### PR DESCRIPTION
When you have more than one request to the server in some test, it would be very helpful to see which one request was failed.

