### PR TITLE
Feature Request: `reply` can't replay with ArrayBuffer, Blob, etc. responses

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -5,7 +5,7 @@ var utils = require('./utils');
 function makeResponse(result, config) {
   return {
     status: result[0],
-    data: utils.isObject(result[1]) ? JSON.parse(JSON.stringify(result[1])) : result[1],
+    data: utils.isSimpleObject(result[1]) ? JSON.parse(JSON.stringify(result[1])) : result[1],
     headers: result[2],
     config: config
   };

--- a/src/utils.js
+++ b/src/utils.js
@@ -111,14 +111,14 @@ function createErrorResponse(message, config, response) {
   return error;
 }
 
-function isObject(value) {
-  return value !== null && typeof value === 'object';
+function isSimpleObject(value) {
+  return value !== null && value !== undefined && value.toString() === '[object Object]';
 }
 
 module.exports = {
   find: find,
   findHandler: findHandler,
-  isObject: isObject,
+  isSimpleObject: isSimpleObject,
   purgeIfReplyOnce: purgeIfReplyOnce,
   settle: settle
 };

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -376,6 +376,23 @@ describe('MockAdapter basics', function() {
     });
   });
 
+  it('allows sending an any object as response', function() {
+    var buffer = new ArrayBuffer(1);
+    var view = new Uint8Array(buffer);
+    view[0] = 0xFF;
+
+    mock.onGet('/').reply(200, buffer);
+
+    return instance({
+      url: '/',
+      method: 'GET',
+      responseType: 'arraybuffer'
+    }).then(function(response) {
+      var view = new Uint8Array(response.data);
+      expect(view[0]).to.equal(0xFF);
+    });
+  });
+
   it('returns a deep copy of the mock data in the response when the data is an object', function() {
     var data = {
       foo: {


### PR DESCRIPTION
### Problem

Let's say I have code like:

```javascript
var buffer = new ArrayBuffer(1);
var view = new Uint8Array(buffer);
view[0] = 0xAA;

mock.onGet('/some-url').reply(200, buffer);
axios({
  url: '/some-url',
  method: 'GET',
  responseType: 'arraybuffer'
}).then(function(response) {
  response.data;  // <-- HERE response.data is not a ArrayBuffer, but an empty object `{}`
});
```

So, I can't mock for example image generator.


### Solution

I've changed a check `isObject` to be way more stricter thus allowing blobs, buffers, files to no be wrapped and unwrapped with JSON converter.

### Notes

I've created a test, but I've not updated documentation since my English is quite bad.