### PR TITLE
Check params if they exist

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,7 @@ function isUrlMatching(url, required) {
 }
 
 function isBodyOrParametersMatching(method, body, parameters, required) {
-  if (method.toLowerCase() === 'get') {
+  if (required !== undefined) {
     var params = required ? required.params : undefined;
     return isParametersMatching(parameters, params);
   } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,8 @@ function isUrlMatching(url, required) {
 }
 
 function isBodyOrParametersMatching(method, body, parameters, required) {
-  if (required !== undefined) {
+  var allowedParamsMethods = ['delete', 'get', 'head', 'options'];
+  if (allowedParamsMethods.indexOf(method.toLowerCase()) >= 0 ) {
     var params = required ? required.params : undefined;
     return isParametersMatching(parameters, params);
   } else {

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -85,7 +85,7 @@ describe('MockAdapter basics', function() {
     });
   });
 
-  it('can pass query params to match to a handler', function() {
+  it('can pass query params for get to match to a handler', function() {
     mock
       .onGet('/withParams', { params: { foo: 'bar', bar: 'foo' } })
       .reply(200);
@@ -94,6 +94,54 @@ describe('MockAdapter basics', function() {
       .get('/withParams', { params: { bar: 'foo', foo: 'bar' }, in: true })
       .then(function(response) {
         expect(response.status).to.equal(200);
+      });
+  });
+
+  it('can pass query params for delete to match to a handler', function() {
+    mock
+      .onDelete('/withParams', { params: { foo: 'bar', bar: 'foo' } })
+      .reply(200);
+
+    return instance
+      .delete('/withParams', { params: { bar: 'foo', foo: 'bar' }, in: true })
+      .then(function(response) {
+        expect(response.status).to.equal(200);
+      });
+  });
+
+  it('can pass query params for head to match to a handler', function() {
+    mock
+      .onHead('/withParams', { params: { foo: 'bar', bar: 'foo' } })
+      .reply(200);
+
+    return instance
+      .head('/withParams', { params: { bar: 'foo', foo: 'bar' }, in: true })
+      .then(function(response) {
+        expect(response.status).to.equal(200);
+      });
+  });
+
+  it('can\'t pass query params for post to match to a handler', function() {
+    mock
+      .onPost('/withParams', { params: { foo: 'bar', bar: 'foo' } })
+      .reply(200);
+
+    return instance
+      .post('/withParams', { params: { foo: 'bar', bar: 'foo' }, in: true })
+      .catch(function(error) {
+        expect(error.response.status).to.equal(404);
+      });
+  });
+
+  it('can\'t pass query params for put to match to a handler', function() {
+    mock
+      .onPut('/withParams', { params: { foo: 'bar', bar: 'foo' } })
+      .reply(200);
+
+    return instance
+      .put('/withParams', { params: { bar: 'foo', foo: 'bar' }, in: true })
+      .catch(function(error) {
+        expect(error.response.status).to.equal(404);
       });
   });
 


### PR DESCRIPTION
In my company we wanted to check params for delete request, which is allowed by axios, so mock also should support it.
Now it would check only params if they exists.