### PR TITLE
feature(index.js): export default class for use in typescript.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,3 +110,5 @@ function addHandler(method, handlers, handler) {
 }
 
 module.exports = MockAdapter;
+// allow default import in typescript
+module.exports.default = MockAdapter;

--- a/src/index.js
+++ b/src/index.js
@@ -109,6 +109,4 @@ function addHandler(method, handlers, handler) {
   }
 }
 
-module.exports = MockAdapter;
-// allow default import in typescript
-module.exports.default = MockAdapter;
+module.exports = module.exports.default = MockAdapter;


### PR DESCRIPTION
This pr allows you to do: `import AxiosMockAdapter from 'axios-mock-adapter';` in Typescript.

cc:
@tkryskiewicz