### PR TITLE
Add options verb support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 var handleRequest = require('./handle_request');
 
-var VERBS = ['get', 'post', 'head', 'delete', 'patch', 'put'];
+var VERBS = ['get', 'post', 'head', 'delete', 'patch', 'put', 'options'];
 
 function adapter() {
   return function(config) {

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -23,6 +23,7 @@ describe('MockAdapter basics', function() {
     expect(mock.onHead).to.be.a('function');
     expect(mock.onDelete).to.be.a('function');
     expect(mock.onPatch).to.be.a('function');
+    expect(mock.onOptions).to.be.a('function');
   });
 
   it('mocks requests', function() {


### PR DESCRIPTION
This PR is to allow `OPTIONS` [preflighted requests ](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests) which is used to check if we are allowed to perform HTTP requests across different domains.