### PR TITLE
Use default import in typescript

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,4 +109,5 @@ function addHandler(method, handlers, handler) {
   }
 }
 
-module.exports = module.exports.default = MockAdapter;
+module.exports = MockAdapter;
+module.exports.default = MockAdapter;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -42,4 +42,4 @@ declare class MockAdapter {
   onAny: RequestMatcherFunc;
 }
 
-export = MockAdapter;
+export default MockAdapter;

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import MockAdapter = require("axios-mock-adapter");
+import MockAdapter from "axios-mock-adapter";
 
 const instance = axios.create();
 const mock = new MockAdapter(instance);


### PR DESCRIPTION
Currently default import is not working in typescript

This should fix it and enable importing adapter as
```
import MockAdapter from "axios-mock-adapter";
```