### PR TITLE
add support for matchers on the concatenation of the baseURL and url properties (fixes #74)

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -17,7 +17,7 @@ function handleRequest(mockAdapter, resolve, reject, config) {
   }
   config.adapter = null;
 
-  var handler = utils.findHandler(mockAdapter.handlers, config.method, config.url, config.data, config.params, config.headers);
+  var handler = utils.findHandler(mockAdapter.handlers, config.method, config.url, config.data, config.params, config.headers, config.baseURL);
 
   if (handler) {
     utils.purgeIfReplyOnce(mockAdapter, handler);

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,12 +18,20 @@ function find(array, predicate) {
   }
 }
 
-function findHandler(handlers, method, url, body, parameters, headers) {
+function combineUrls(baseURL, url) {
+  if (baseURL) {
+    return baseURL.replace(/\/+$/, '') + '/' + url.replace(/\/+$/, '');
+  }
+
+  return url;
+}
+
+function findHandler(handlers, method, url, body, parameters, headers, baseURL) {
   return find(handlers[method.toLowerCase()], function(handler) {
     if (typeof handler[0] === 'string') {
-      return isUrlMatching(url, handler[0]) && isBodyOrParametersMatching(method, body, parameters, handler[1])  && isRequestHeadersMatching(headers, handler[2]);
+      return (isUrlMatching(url, handler[0]) || isUrlMatching(combineUrls(baseURL, url), handler[0])) && isBodyOrParametersMatching(method, body, parameters, handler[1])  && isRequestHeadersMatching(headers, handler[2]);
     } else if (handler[0] instanceof RegExp) {
-      return handler[0].test(url) && isBodyOrParametersMatching(method, body, parameters, handler[1]) && isRequestHeadersMatching(headers, handler[2]);
+      return (handler[0].test(url) || handler[0].test(combineUrls(baseURL, url))) && isBodyOrParametersMatching(method, body, parameters, handler[1]) && isRequestHeadersMatching(headers, handler[2]);
     }
   });
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,7 +20,7 @@ function find(array, predicate) {
 
 function combineUrls(baseURL, url) {
   if (baseURL) {
-    return baseURL.replace(/\/+$/, '') + '/' + url.replace(/\/+$/, '');
+    return baseURL.replace(/\/+$/, '') + '/' + url.replace(/^\/+/, '');
   }
 
   return url;

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -296,6 +296,28 @@ describe('MockAdapter basics', function() {
     });
   });
 
+  // https://github.com/ctimmerm/axios-mock-adapter/issues/74
+  it('allows mocks to match on the result of concatenating baseURL and url', () => {
+    instance.defaults.baseURL = 'http://www.example.org/api/v1/';
+
+    mock.onGet('http://www.example.org/api/v1/foo').reply(200);
+
+    return instance.get('/foo').then(function (response) {
+      expect(response.status).to.equal(200);
+    });
+  });
+
+  // https://github.com/ctimmerm/axios-mock-adapter/issues/74
+  it('allows mocks to match on the result of concatenating baseURL and url with a regex', () => {
+    instance.defaults.baseURL = 'http://www.example.org/api/v1/';
+
+    mock.onGet(/\/api\/v1\/foo$/).reply(200);
+
+    return instance.get('/foo').then(function (response) {
+      expect(response.status).to.equal(200);
+    });
+  });
+
   it('allows multiple consecutive requests for the mocked url', function() {
     mock.onGet('/foo').reply(200);
 


### PR DESCRIPTION
This adds support for the use case defined in #74, a matcher on the concatenation of `config.baseURL` and `config.url`. In other words, the following will be supported where it wasn't before:

```js
const axios = require('axios');
const MockAdapter = require('axios-mock-adapter');

const mock = new MockAdapter(axios);

mock.onGet('/api/v1/test').reply(200);

const reqOptions = {
  method: 'GET',
  baseURL: '/api/v1',
  url: '/test',
};

axios(reqOptions).then((response) => {
  console.log(response.status); // => 200
});
```