### PR TITLE
Existing mock should be overwritten when new mock is defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,9 +106,9 @@ function addHandler(method, handlers, handler) {
     });
   } else {
     if (handlers[method].length) {
-      handlers[method].forEach((item, index) => {
+      handlers[method].forEach(function(item, index) {
         if (item[0] === handler[0]) {
-          handlers[method].splice(index, 1, handler)
+          handlers[method].splice(index, 1, handler);
         }
         handlers[method].push(handler);
       });

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,16 @@ function addHandler(method, handlers, handler) {
       handlers[verb].push(handler);
     });
   } else {
-    handlers[method].push(handler);
+    if (handlers[method].length) {
+      handlers[method].forEach((item, index) => {
+        if (item[0] === handler[0]) {
+          handlers[method].splice(index, 1, handler)
+        }
+        handlers[method].push(handler);
+      });
+    } else {
+      handlers[method].push(handler);
+    }
   }
 }
 

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -528,4 +528,27 @@ describe('MockAdapter basics', function() {
         expect(data[0].bar).to.equal(123);
       });
   });
+
+  it('should overwrite existing mock', function() {
+    var data = [
+      {
+        bar: 123
+      }
+    ];
+
+    var data2 = [
+      {
+        bar: 321
+      }
+    ];
+
+    mock.onGet('/').reply(200, data);
+    mock.onGet('/').reply(200, data2);
+
+    return instance
+      .get('/')
+      .then(function(response) {
+        expect(response.data).to.deep.equal(data2);
+      });
+  });
 });


### PR DESCRIPTION
Ran into the following situation:
```
mock.onGet('/').reply(200);
mock.onGet('/').reply(500);

axios.get('/).then(() => console.log('then')).catch(err => console.log(err))
```
.catch will be called as handlers.get array now has 2 mocks for the same endpoint but we iterate from the top down never hitting the second. 

This PR will check to see if a `handler` exist on a `method`, if so it will replace the existing handler with the new handler.

The reason I created this PR is that I am using axios-mock-adapter to set up my initial mocks across all of my endpoints (for local development without having to VPN into our network). When I go to test a different response/status on x endpoint it defaults to the initial calls. I tried to use replyOnce but that gave weird results as the webapp makes calls to some of the endpoints multiple times. This was the only solution I could come up with.