### PR TITLE
Use the adapter on the MockAdapter instance

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ function MockAdapter(axiosInstance, options) {
     this.axiosInstance = axiosInstance;
     this.originalAdapter = axiosInstance.defaults.adapter;
     this.delayResponse = options && options.delayResponse > 0 ? options.delayResponse : null;
-    axiosInstance.defaults.adapter = adapter.call(this);
+    axiosInstance.defaults.adapter = this.adapter.call(this);
   }
 }
 


### PR DESCRIPTION
This allows extending of the default MockAdapter adapter

There's already the `MockAdapter.prototype.adapter = adapter;` line, so this just takes advantage of that