### PR TITLE
Overwrite existing mocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,10 +135,6 @@ function findInReplyOnceHandler(handler, replyOnceHandlers) {
   return index;
 }
 
-function replaceHandler(method, handlers, handler, index) {
-  handlers[method].splice(index, 1, handler);
-}
-
 function addHandlerReplyOnce(method, handlers, handler) {
   if (method === 'any') {
     VERBS.forEach(function(verb) {
@@ -161,7 +157,7 @@ function addHandler(method, handlers, handler, replyOnceHandlers) {
       if (indexOfExistingReplyOnceHandler > -1 ) {
         handlers[method].push(handler);
       } else {
-        replaceHandler(method, handlers, handler, indexOfExistingHandler);
+        handlers[method].splice(indexOfExistingHandler, 1, handler);
       }
     } else {
       handlers[method].push(handler);

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ VERBS.concat('any').forEach(function(method) {
 
     function reply(code, response, headers) {
       var handler = [matcher, body, requestHeaders, code, response, headers];
-      addHandler(method, _this.handlers, handler);
+      addHandler(method, _this.handlers, handler, _this.replyOnceHandlers);
       return _this;
     }
 
@@ -67,7 +67,7 @@ VERBS.concat('any').forEach(function(method) {
 
       replyOnce: function replyOnce(code, response, headers) {
         var handler = [matcher, body, requestHeaders, code, response, headers];
-        addHandler(method, _this.handlers, handler);
+        addHandlerReplyOnce(method, _this.handlers, handler);
         _this.replyOnceHandlers.push(handler);
         return _this;
       },
@@ -99,13 +99,73 @@ VERBS.concat('any').forEach(function(method) {
   };
 });
 
-function addHandler(method, handlers, handler) {
+function findInHandler(method, handlers, handler) {
+  var index = -1;
+  for (var i = 0; i < handlers[method].length; i += 1) {
+    var item = handlers[method][i];
+    var isSame = (
+      item[0] === handler[0] &&
+      item[1] === handler[1] &&
+      item[2] === handler[2]
+    );
+
+    if (isSame) {
+      index =  i;
+    }
+  }
+  return index;
+}
+
+function findInReplyOnceHandler(handler, replyOnceHandlers) {
+  var index = -1;
+  if (replyOnceHandlers && replyOnceHandlers.length) {
+    for (var i = 0; i < replyOnceHandlers.length; i += 1) {
+      var item = replyOnceHandlers[i];
+      var isInReplyOnce = (
+        item[0] === handler[0] &&
+        item[1] === handler[1] &&
+        item[2] === handler[2]
+      );
+
+      if (isInReplyOnce) {
+        index = i;
+      }
+    }
+  }
+  return index;
+}
+
+function replaceHandler(method, handlers, handler, index) {
+  handlers[method].splice(index, 1, handler);
+}
+
+function addHandlerReplyOnce(method, handlers, handler) {
   if (method === 'any') {
     VERBS.forEach(function(verb) {
       handlers[verb].push(handler);
     });
   } else {
     handlers[method].push(handler);
+  }
+}
+
+function addHandler(method, handlers, handler, replyOnceHandlers) {
+  if (method === 'any') {
+    VERBS.forEach(function(verb) {
+      handlers[verb].push(handler);
+    });
+  } else {
+    var indexOfExistingHandler = findInHandler(method, handlers, handler);
+    var indexOfExistingReplyOnceHandler = findInReplyOnceHandler(handler, replyOnceHandlers);
+    if (indexOfExistingHandler > -1) {
+      if (indexOfExistingReplyOnceHandler > -1 ) {
+        handlers[method].push(handler);
+      } else {
+        replaceHandler(method, handlers, handler, indexOfExistingHandler);
+      }
+    } else {
+      handlers[method].push(handler);
+    }
   }
 }
 

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -540,7 +540,7 @@ describe('MockAdapter basics', function() {
       });
   });
 
-  it.only('should not add duplicate handlers', function() {
+  it('should not add duplicate handlers', function() {
     mock.onGet('/').replyOnce(312);
     mock.onGet('/').reply(200);
     mock.onGet('/1').reply(200);


### PR DESCRIPTION
I believe this will fix the issues from PR #109 as well as a different bug from #109 where mocks were getting added way too many times due to a forEach loop. With 25 onGet mocks being called with different paths and using `.reply()` my `mock.handlers.get.length` was 16,777,216.

Let me know if you have any other test that I should verify before this gets merged in or any code I can clean up