### PR TITLE
Investigating new handlers structure

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -20,8 +20,6 @@ function handleRequest(mockAdapter, resolve, reject, config) {
   var handler = utils.findHandler(mockAdapter.handlers, config.method, config.url, config.data, config.params, config.headers, config.baseURL);
 
   if (handler) {
-    utils.purgeIfReplyOnce(mockAdapter, handler);
-
     if (handler.length === 2) { // passThrough handler
       // tell axios to use the original adapter instead of our mock, fixes #35
       config.adapter = mockAdapter.originalAdapter;
@@ -30,7 +28,12 @@ function handleRequest(mockAdapter, resolve, reject, config) {
         .request(config)
         .then(resolve, reject);
     } else if (!(handler[3] instanceof Function)) {
-      utils.settle(resolve, reject, makeResponse(handler.slice(3), config), mockAdapter.delayResponse);
+      if (handler.length === 7) {
+        utils.purgeIfReplyOnce(mockAdapter, handler);
+        utils.settle(resolve, reject, makeResponse(handler.slice(3), config), mockAdapter.delayResponse);
+      } else {
+        utils.settle(resolve, reject, makeResponse(handler.slice(3), config), mockAdapter.delayResponse);
+      }
     } else {
       var result = handler[3](config);
       // TODO throw a sane exception when return value is incorrect

--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -36,7 +36,12 @@ function handleRequest(mockAdapter, resolve, reject, config) {
       if (handler.length === 7) {
         utils.purgeIfReplyOnce(mockAdapter, handler);
       }
-      utils.settle(resolve, reject, makeResponse(handler.slice(3), config), mockAdapter.delayResponse);
+      utils.settle(
+        resolve,
+        reject,
+        makeResponse(handler.slice(3), config),
+        mockAdapter.delayResponse
+      );
     } else {
       var result = handler[3](config);
       // TODO throw a sane exception when return value is incorrect

--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -30,10 +30,8 @@ function handleRequest(mockAdapter, resolve, reject, config) {
     } else if (!(handler[3] instanceof Function)) {
       if (handler.length === 7) {
         utils.purgeIfReplyOnce(mockAdapter, handler);
-        utils.settle(resolve, reject, makeResponse(handler.slice(3), config), mockAdapter.delayResponse);
-      } else {
-        utils.settle(resolve, reject, makeResponse(handler.slice(3), config), mockAdapter.delayResponse);
       }
+      utils.settle(resolve, reject, makeResponse(handler.slice(3), config), mockAdapter.delayResponse);
     } else {
       var result = handler[3](config);
       // TODO throw a sane exception when return value is incorrect

--- a/src/index.js
+++ b/src/index.js
@@ -101,8 +101,11 @@ function findInHandlers(method, handlers, handler) {
   for (var i = 0; i < handlers[method].length; i += 1) {
     var item = handlers[method][i];
     var isReplyOnce = item.length === 7;
+    var comparePaths = item[0] instanceof RegExp && handler[0] instanceof RegExp
+      ? deepEqual(String(item[0]), String(handler[0]))
+      : deepEqual(item[0], handler[0]);
     var isSame = (
-      deepEqual(item[0], handler[0]) &&
+      comparePaths &&
       deepEqual(item[1], handler[1]) &&
       deepEqual(item[2], handler[2])
     );

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,6 @@ function reset() {
     accumulator[verb] = [];
     return accumulator;
   }, {});
-  this.replyOnceHandlers = [];
 }
 
 function MockAdapter(axiosInstance, options) {
@@ -68,7 +67,6 @@ VERBS.concat('any').forEach(function(method) {
       replyOnce: function replyOnce(code, response, headers) {
         var handler = [matcher, body, requestHeaders, code, response, headers, true];
         addHandler(method, _this.handlers, handler);
-        _this.replyOnceHandlers.push(handler);
         return _this;
       },
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var deepEqual = require('deep-equal');
+
 var handleRequest = require('./handle_request');
 
 var VERBS = ['get', 'post', 'head', 'delete', 'patch', 'put', 'options'];
@@ -100,9 +102,9 @@ function findInHandlers(method, handlers, handler) {
     var item = handlers[method][i];
     var isReplyOnce = item.length === 7;
     var isSame = (
-      item[0] === handler[0] &&
-      item[1] === handler[1] &&
-      item[2] === handler[2]
+      deepEqual(item[0], handler[0]) &&
+      deepEqual(item[1], handler[1]) &&
+      deepEqual(item[2], handler[2])
     );
     if (isSame && !isReplyOnce) {
       index =  i;

--- a/src/index.js
+++ b/src/index.js
@@ -97,13 +97,35 @@ VERBS.concat('any').forEach(function(method) {
   };
 });
 
+function findInHandlers(method, handlers, handler) {
+  var index = -1;
+  for (var i = 0; i < handlers[method].length; i += 1) {
+    var item = handlers[method][i];
+    var isReplyOnce = item.length === 7;
+    var isSame = (
+      item[0] === handler[0] &&
+      item[1] === handler[1] &&
+      item[2] === handler[2]
+    );
+    if (isSame && !isReplyOnce) {
+      index =  i;
+    }
+  }
+  return index;
+}
+
 function addHandler(method, handlers, handler) {
   if (method === 'any') {
     VERBS.forEach(function(verb) {
       handlers[verb].push(handler);
     });
   } else {
-    handlers[method].push(handler);
+    var indexOfExistingHandler = findInHandlers(method, handlers, handler);
+    if (indexOfExistingHandler > -1 && handler.length < 7) {
+      handlers[method].splice(indexOfExistingHandler, 1, handler);
+    } else {
+      handlers[method].push(handler);
+    }
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -102,8 +102,8 @@ function findInHandlers(method, handlers, handler) {
     var item = handlers[method][i];
     var isReplyOnce = item.length === 7;
     var comparePaths = item[0] instanceof RegExp && handler[0] instanceof RegExp
-      ? deepEqual(String(item[0]), String(handler[0]))
-      : deepEqual(item[0], handler[0]);
+      ? String(item[0]) === String(handler[0])
+      : item[0] === handler[0];
     var isSame = (
       comparePaths &&
       deepEqual(item[1], handler[1]) &&

--- a/src/index.js
+++ b/src/index.js
@@ -106,8 +106,8 @@ function findInHandlers(method, handlers, handler) {
       : item[0] === handler[0];
     var isSame = (
       comparePaths &&
-      deepEqual(item[1], handler[1]) &&
-      deepEqual(item[2], handler[2])
+      deepEqual(item[1], handler[1], { strict: true }) &&
+      deepEqual(item[2], handler[2], { strict: true })
     );
     if (isSame && !isReplyOnce) {
       index =  i;

--- a/src/index.js
+++ b/src/index.js
@@ -66,7 +66,7 @@ VERBS.concat('any').forEach(function(method) {
       reply: reply,
 
       replyOnce: function replyOnce(code, response, headers) {
-        var handler = [matcher, body, requestHeaders, code, response, headers];
+        var handler = [matcher, body, requestHeaders, code, response, headers, true];
         addHandler(method, _this.handlers, handler);
         _this.replyOnceHandlers.push(handler);
         return _this;

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,17 +75,12 @@ function isBodyMatching(body, requiredBody) {
 }
 
 function purgeIfReplyOnce(mock, handler) {
-  var index = mock.replyOnceHandlers.indexOf(handler);
-  if (index > -1) {
-    mock.replyOnceHandlers.splice(index, 1);
-
-    Object.keys(mock.handlers).forEach(function(key) {
-      index = mock.handlers[key].indexOf(handler);
-      if (index > -1) {
-        mock.handlers[key].splice(index, 1);
-      }
-    });
-  }
+  Object.keys(mock.handlers).forEach(function(key) {
+    var index = mock.handlers[key].indexOf(handler);
+    if (index > -1) {
+      mock.handlers[key].splice(index, 1);
+    }
+  });
 }
 
 function settle(resolve, reject, response, delay) {

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -593,6 +593,22 @@ describe('MockAdapter basics', function() {
       });
   });
 
+  it.only('should overwrite replys using RegEx', function() {
+    mock.onGet(/foo\/bar/).reply(500);
+    mock.onGet(/foo\/bar/).reply(200);
+    mock.onGet(/foo\/baz\/.+/).reply(200);
+
+    return instance.get('/foo/bar')
+      .then(function(response) {
+        expect(mock.handlers['get'].length).to.equal(2);
+        expect(response.status).to.equal(200);
+        return instance.get('/foo/baz/56');
+      })
+      .then(function(response) {
+        expect(response.status).to.equal(200);
+      });
+  });
+
   it('should allow overwriting only on reply if replyOnce was used first', function() {
     var counter = 0;
     mock.onGet('/').replyOnce(500);

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -556,7 +556,7 @@ describe('MockAdapter basics', function() {
     expect(mock.handlers['get'].length).to.equal(7);
   });
 
-  it('supports chaining on same path with different params', function () {
+  it('supports chaining on same path with different params', function() {
     mock
       .onGet('/users', { params: { searchText: 'John' } }).reply(200, { id: 1 })
       .onGet('/users', { params: { searchText: 'James' } }).reply(200, { id: 2 })
@@ -564,22 +564,22 @@ describe('MockAdapter basics', function() {
       .onGet('/users', { params: { searchText: 'Jackie' } }).reply(200, { id: 4 });
 
     return instance.get('/users', { params: { searchText: 'John' } })
-      .then(function (response) {
+      .then(function(response) {
         expect(response.data.id).to.equal(1);
         return instance.get('/users', { params: { searchText: 'James' } });
       })
-      .then(function (response) {
+      .then(function(response) {
         expect(response.data.id).to.equal(2);
         return instance.get('/users', { params: { searchText: 'Jake' } });
       })
-      .then(function (response) {
+      .then(function(response) {
         expect(response.data.id).to.equal(3);
         return instance.get('/users', { params: { searchText: 'Jackie' } });
       })
-      .then(function (response) {
+      .then(function(response) {
         expect(response.data.id).to.equal(4);
       });
-  })
+  });
 
   it('should overwrite replys', function() {
     mock.onGet('/').reply(500);
@@ -590,8 +590,8 @@ describe('MockAdapter basics', function() {
       .catch(function(error) {
         expect(mock.handlers['get'].length).to.equal(1);
         expect(error.response.status).to.equal(401);
-      })
-  })
+      });
+  });
 
   it('should allow overwriting only on reply if replyOnce was used first', function() {
     var counter = 0;
@@ -603,16 +603,18 @@ describe('MockAdapter basics', function() {
       .catch(function(error) {
         expect(error.response.status).to.equal(500);
         counter += 1;
-        return instance.get('/')
+        return instance.get('/');
       })
       .catch(function(error) {
         expect(error.response.status).to.equal(401);
         counter += 1;
       })
-      .then(function() { expect(counter).to.equal(2)});
+      .then(function() {
+        expect(counter).to.equal(2);
+      });
   });
 
-  it('should not allow overwriting only on reply if replyOnce wasn\'t used first', function () {
+  it('should not allow overwriting only on reply if replyOnce wasn\'t used first', function() {
     var counter = 0;
     mock.onGet('/').reply(200);
     mock.onGet('/').reply(401);
@@ -620,15 +622,17 @@ describe('MockAdapter basics', function() {
     mock.onGet('/').reply(500);
 
     return instance.get('/')
-      .catch(function (error) {
+      .catch(function(error) {
         expect(error.response.status).to.equal(500);
         counter += 1;
-        return instance.get('/')
+        return instance.get('/');
       })
-      .catch(function (error) {
+      .catch(function(error) {
         expect(error.response.status).to.equal(500);
         counter += 1;
       })
-      .then(function () { expect(counter).to.equal(2) });
-  })
+      .then(function() {
+        expect(counter).to.equal(2);
+      });
+  });
 });

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -635,4 +635,26 @@ describe('MockAdapter basics', function() {
         expect(counter).to.equal(2);
       });
   });
+  it('allows overwriting mocks with parameters', function() {
+    mock
+      .onGet('/users', { params: { searchText: 'John' } })
+      .reply(500)
+      .onGet('/users', { params: { searchText: 'John' } })
+      .reply(200, { id: 1 });
+
+    return instance.get('/users', { params: { searchText: 'John' } })
+      .then(function(response) {
+        expect(response.status).to.equal(200);
+      });
+  });
+
+  it('allows overwriting mocks with headers', function() {
+    mock.onGet('/').reply(200, {}, { test: true });
+    mock.onGet('/').reply(200, {}, { test: false });
+
+    return instance.get('/')
+      .then(function(response) {
+        expect(response.headers).to.deep.equal({ test: false });
+      });
+  });
 });

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -593,7 +593,7 @@ describe('MockAdapter basics', function() {
       });
   });
 
-  it.only('should overwrite replys using RegEx', function() {
+  it('should overwrite replys using RegEx', function() {
     mock.onGet(/foo\/bar/).reply(500);
     mock.onGet(/foo\/bar/).reply(200);
     mock.onGet(/foo\/baz\/.+/).reply(200);
@@ -664,13 +664,11 @@ describe('MockAdapter basics', function() {
       });
   });
 
-  it('allows overwriting mocks with headers', function() {
-    mock.onGet('/').reply(200, {}, { test: true });
-    mock.onGet('/').reply(200, {}, { test: false });
+  it.only('allows overwriting mocks with headers', function() {
+    mock.onGet('/', {}, { 'Accept-Charset': 'utf-8' }).reply(500);
+    mock.onGet('/', {}, { 'Accept-Charset': 'utf-8' }).reply(200);
 
-    return instance.get('/')
-      .then(function(response) {
-        expect(response.headers).to.deep.equal({ test: false });
-      });
+    expect(mock.handlers['get'].length).to.equal(1);
+    expect(mock.handlers['get'][0][3]).to.equal(200);
   });
 });

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -528,4 +528,82 @@ describe('MockAdapter basics', function() {
         expect(data[0].bar).to.equal(123);
       });
   });
+
+  it('should overwrite existing mock', function() {
+    mock.onGet('/').reply(500);
+    mock.onGet('/').reply(200);
+
+    return instance
+      .get('/')
+      .then(function(response) {
+        expect(response.status).to.equal(200);
+      });
+  });
+
+  it('should not add duplicate handlers', function() {
+    mock.onGet('/').replyOnce(312);
+    mock.onGet('/').reply(200);
+    mock.onGet('/1').reply(200);
+    mock.onGet('/2').reply(200);
+    mock.onGet('/3').replyOnce(300);
+    mock.onGet('/3').reply(200);
+    mock.onGet('/4').reply(200);
+
+    expect(mock.handlers['get'].length).to.equal(7);
+    expect(mock.replyOnceHandlers.length).to.equal(2);
+  });
+
+  it('supports chaining on same path with different params', function () {
+    mock
+      .onGet('/users', { params: { searchText: 'John' } }).reply(200, { id: 1 })
+      .onGet('/users', { params: { searchText: 'James' } }).reply(200, { id: 2 })
+      .onGet('/users', { params: { searchText: 'Jake' } }).reply(200, { id: 3 })
+      .onGet('/users', { params: { searchText: 'Jackie' } }).reply(200, { id: 4 });
+
+    return instance.get('/users', { params: { searchText: 'John' } })
+      .then(function (response) {
+        expect(response.data.id).to.equal(1);
+        return instance.get('/users', { params: { searchText: 'James' } });
+      })
+      .then(function (response) {
+        expect(response.data.id).to.equal(2);
+        return instance.get('/users', { params: { searchText: 'Jake' } });
+      })
+      .then(function (response) {
+        expect(response.data.id).to.equal(3);
+        return instance.get('/users', { params: { searchText: 'Jackie' } });
+      })
+      .then(function (response) {
+        expect(response.data.id).to.equal(4);
+      });
+  })
+
+  it('should overwrite replys', function() {
+    mock.onGet('/').reply(500);
+    mock.onGet('/').reply(200);
+    mock.onGet('/').reply(401);
+
+    return instance.get('/')
+      .catch(function(error) {
+        expect(mock.handlers['get'].length).to.equal(1);
+        expect(error.response.status).to.equal(401);
+      })
+  })
+
+  it('should allow overwriting on reply when using replyOnce', function() {
+    mock.onGet('/').replyOnce(500);
+    mock.onGet('/').reply(200);
+    mock.onGet('/').reply(401);
+
+    console.log('mock', JSON.stringify(mock, null, 2));
+    return instance.get('/')
+      .catch(function(error) {
+        console.log('mock', JSON.stringify(mock, null, 2));
+        expect(error.response.status).to.equal(500);
+        return instance.get('/')
+      })
+      .catch(function(error) {
+        expect(error.response.status).to.equal(401);
+      });
+  })
 });


### PR DESCRIPTION
NOTE: I closed out #114 as I feel this is a better/easier way of handling this. I removed the replyOnceHandlers as that made it super complicated for overwriting mocks. Now the replyOnce function will pass an array that has a length of 7 to addHandler. This allows us to check to see if a handler is a replyOnce handler or not. The following text is from PR #114.

I believe this will fix the issues from PR #109 as well as a different bug from #109 where mocks were getting added way too many times due to a forEach loop. With 25 onGet mocks being called with different paths and using .reply() my mock.handlers.get.length was 16,777,216.

Let me know if you have any other test that I should verify before this gets merged in or any code I can clean up