### PR TITLE
support for mocks when an interceptor retries a request

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -15,7 +15,7 @@ function handleRequest(mockAdapter, resolve, reject, config) {
   if (config.baseURL && config.url.substr(0, config.baseURL.length) === config.baseURL) {
     config.url = config.url.slice(config.baseURL ? config.baseURL.length : 0);
   }
-  config.adapter = null;
+  delete config.adapter;
 
   var handler = utils.findHandler(
     mockAdapter.handlers,

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -676,4 +676,18 @@ describe('MockAdapter basics', function() {
     expect(mock.handlers['get'].length).to.equal(1);
     expect(mock.handlers['get'][0][3]).to.equal(200);
   });
+
+  it('supports a retry', function() {
+    mock.onGet('/').replyOnce(401);
+    mock.onGet('/').replyOnce(201);
+    instance.interceptors.response.use(undefined, function(error) {
+      if (error.response && error.response.status === 401) {
+        return instance(error.config);
+      }
+      return Promise.reject(error);
+    });
+    return instance({ method: 'get', url: '/' }).then(function(response) {
+      expect(response.status).to.equal(201);
+    });
+  });
 });


### PR DESCRIPTION
I found that if I have an interceptor that was attempting to retry a request (perhaps an interceptor that checks for 401 response codes, then requests a new oauth2 token, then retries the request) it wouldn't use the mock adapter for the retried attempts. I found that in the handle request, we setting the adapter to null. Instead we should actually delete the adapter so axios will use the instance default one.

Looks like this is also the same scenario as issue #68. Essentially any time we tried to retry a request in an interceptor using the same config, it was bypassing the mock adapter and making a real request which is why in Issue #68 they were seeing it give a 404 response code back.