### PR TITLE
Include method and URL in 'Request failed' error message

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -83,6 +83,10 @@ function purgeIfReplyOnce(mock, handler) {
   });
 }
 
+function describeConfig(config) {
+  return config.method.toUpperCase() + ' ' + config.url;
+}
+
 function settle(resolve, reject, response, delay) {
   if (delay > 0) {
     setTimeout(function() {
@@ -95,7 +99,7 @@ function settle(resolve, reject, response, delay) {
     response.config.validateStatus(response.status)
       ? resolve(response)
       : reject(createErrorResponse(
-        'Request failed with status code ' + response.status,
+        'Request failed (' + describeConfig(response.config) + ') with status code ' + response.status,
         response.config,
         response
       ));

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -331,6 +331,7 @@ describe('MockAdapter basics', function() {
     return instance.get('/foo').catch(function(error) {
       expect(error).to.be.an.instanceof(Error);
       expect(error.message).to.match(/request failed/i);
+      expect(error.message).to.match(/GET \/foo/i);
     });
   });
 


### PR DESCRIPTION
This makes the error message much more helpful for frameworks such as Jest which usually just output the exception/promise rejection reason by default.

Before:

```
● <Component /> › renders

    Request failed with status code 404
       at createErrorResponse (node_modules/axios-mock-adapter/src/utils.js)
```

After:


```
● <Component /> › renders

    Request failed (POST /foo/baz/bar/quux/) with status code 404
       at createErrorResponse (node_modules/axios-mock-adapter/src/utils.js)
```
