### PR TITLE
Implemented history to record all calls to the mock

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -16,6 +16,7 @@ function handleRequest(mockAdapter, resolve, reject, config) {
     config.url = config.url.slice(config.baseURL ? config.baseURL.length : 0);
   }
   config.adapter = null;
+  mockAdapter.history[config.method].push(config);
 
   var handler = utils.findHandler(
     mockAdapter.handlers,

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,11 @@ function getVerbObject() {
 }
 
 function reset() {
+  resetHandlers.call(this);
+  resetHistory.call(this);
+}
+
+function resetHandlers() {
   this.handlers = getVerbObject();
 }
 
@@ -38,7 +43,6 @@ function resetHistory() {
 
 function MockAdapter(axiosInstance, options) {
   reset.call(this);
-  resetHistory.call(this);
 
   if (axiosInstance) {
     this.axiosInstance = axiosInstance;
@@ -57,6 +61,7 @@ MockAdapter.prototype.restore = function restore() {
 };
 
 MockAdapter.prototype.reset = reset;
+MockAdapter.prototype.resetHandlers = resetHandlers;
 MockAdapter.prototype.resetHistory = resetHistory;
 
 VERBS.concat('any').forEach(function(method) {

--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,24 @@ function adapter() {
   }.bind(this);
 }
 
-function reset() {
-  this.handlers = VERBS.reduce(function(accumulator, verb) {
+function getVerbObject() {
+  return VERBS.reduce(function(accumulator, verb) {
     accumulator[verb] = [];
     return accumulator;
   }, {});
 }
 
+function reset() {
+  this.handlers = getVerbObject();
+}
+
+function resetHistory() {
+  this.history = getVerbObject();
+}
+
 function MockAdapter(axiosInstance, options) {
   reset.call(this);
+  resetHistory.call(this);
 
   if (axiosInstance) {
     this.axiosInstance = axiosInstance;
@@ -48,6 +57,7 @@ MockAdapter.prototype.restore = function restore() {
 };
 
 MockAdapter.prototype.reset = reset;
+MockAdapter.prototype.resetHistory = resetHistory;
 
 VERBS.concat('any').forEach(function(method) {
   var methodName = 'on' + method.charAt(0).toUpperCase() + method.slice(1);

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -384,6 +384,31 @@ describe('MockAdapter basics', function() {
     expect(mock.handlers['get']).to.be.empty;
   });
 
+  it('resets the history', function() {
+    mock.onAny('/foo').reply(200);
+
+    return instance
+      .get('/foo')
+      .then(function(response) {
+        mock.reset();
+        expect(mock.history['get']).to.eql([]);
+      });
+  });
+
+  it('resets only the registered mock handlers, not the history', function() {
+    mock.onAny('/foo').reply(200);
+    expect(mock.handlers['get']).not.to.be.empty;
+    expect(mock.history['get']).to.eql([]);
+
+    return instance
+      .get('/foo')
+      .then(function(response) {
+        mock.resetHandlers();
+        expect(mock.history.get.length).to.equal(1);
+        expect(mock.handlers['get']).to.be.empty;
+      });
+  });
+
   it('can chain calls to add mock handlers', function() {
     mock
       .onGet('/foo')

--- a/test/history.spec.js
+++ b/test/history.spec.js
@@ -1,0 +1,43 @@
+var axios = require('axios');
+var expect = require('chai').expect;
+
+var MockAdapter = require('../src');
+
+describe('MockAdapter history', function() {
+  var instance;
+  var mock;
+
+  beforeEach(function() {
+    instance = axios.create();
+    mock = new MockAdapter(instance);
+  });
+
+  it('initializes empty history for each http method', function() {
+    expect(mock.history['get']).to.eql([]);
+    expect(mock.history['post']).to.eql([]);
+    expect(mock.history['put']).to.eql([]);
+  });
+
+  it('records the axios config each time the handler is invoked', function() {
+    mock.onAny('/foo').reply(200);
+
+    return instance
+      .get('/foo')
+      .then(function(response) {
+        expect(mock.history.get.length).to.equal(1);
+        expect(mock.history.get[0].method).to.equal('get');
+        expect(mock.history.get[0].url).to.equal('/foo');
+      });
+  });
+
+  it('reset history should reset all history', function() {
+    mock.onAny('/foo').reply(200);
+
+    return instance
+      .get('/foo')
+      .then(function(response) {
+        mock.resetHistory();
+        expect(mock.history['get']).to.eql([]);
+      });
+  });
+});


### PR DESCRIPTION
This modification records each interaction with mock axios, so that a user can write tests which verify a particular call was made. For example, the code under test may make a POST, and perhaps does not do anything with the data that is returned. By checking the history of the mock interactions, a user could write a test which confirms that POST was made.

Unit tests were also written for this new functionality. 