### PR TITLE
Make Request failed error message more clear

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -95,7 +95,7 @@ function settle(resolve, reject, response, delay) {
     response.config.validateStatus(response.status)
       ? resolve(response)
       : reject(createErrorResponse(
-        'Request failed with status code ' + response.status,
+        'Request failed with status code ' + response.status + '\n' + 'Response config ' + JSON.stringify(response.config),
         response.config,
         response
       ));


### PR DESCRIPTION
Sometimes you don't know which request failed so I added `Response config` to ErrorResponse.
Ps: it's really helpful especially if you have many requests.