### PR TITLE
fix: use a local variable instead of modifying config.url

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -12,8 +12,9 @@ function makeResponse(result, config) {
 }
 
 function handleRequest(mockAdapter, resolve, reject, config) {
+  var url = config.url;
   if (config.baseURL && config.url.substr(0, config.baseURL.length) === config.baseURL) {
-    config.url = config.url.slice(config.baseURL ? config.baseURL.length : 0);
+    url = config.url.slice(config.baseURL ? config.baseURL.length : 0);
   }
 
   delete config.adapter;
@@ -22,7 +23,7 @@ function handleRequest(mockAdapter, resolve, reject, config) {
   var handler = utils.findHandler(
     mockAdapter.handlers,
     config.method,
-    config.url,
+    url,
     config.data,
     config.params,
     config.headers,


### PR DESCRIPTION
This keeps the URL consistent with what axios outputs by default.

When you have `baseURL` set in your default configuration, this library [strips it out of the `config.url` property](https://github.com/ctimmerm/axios-mock-adapter/blob/master/src/handle_request.js#L16) returned by the response.  This is inconsistent with the behavior of axios, which contains the fully qualified URL.

This causes libraries like `axios-cookiejar-support` to stop working because the cookie domain is validated against the domain parsed from this property.

See a reproduction of the issue here:
https://runkit.com/szdc/5b249bb0d0d7790012fc868d