### PR TITLE
call axiosInstance responseInterceptors before resolving response

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -30,7 +30,7 @@ function handleRequest(mockAdapter, resolve, reject, config) {
     config.baseURL
   );
 
-  let responseInterceptors = mockAdapter.axiosInstance.interceptors.response;
+  var responseInterceptors = mockAdapter.axiosInstance.interceptors.response;
   if (handler) {
     if (handler.length === 7) {
       utils.purgeIfReplyOnce(mockAdapter, handler);

--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -30,6 +30,7 @@ function handleRequest(mockAdapter, resolve, reject, config) {
     config.baseURL
   );
 
+  let responseInterceptors = mockAdapter.axiosInstance.interceptors.response;
   if (handler) {
     if (handler.length === 7) {
       utils.purgeIfReplyOnce(mockAdapter, handler);
@@ -45,17 +46,18 @@ function handleRequest(mockAdapter, resolve, reject, config) {
         resolve,
         reject,
         makeResponse(handler.slice(3), config),
-        mockAdapter.delayResponse
+        mockAdapter.delayResponse,
+        responseInterceptors
       );
     } else {
       var result = handler[3](config);
       // TODO throw a sane exception when return value is incorrect
       if (typeof result.then !== 'function') {
-        utils.settle(resolve, reject, makeResponse(result, config), mockAdapter.delayResponse);
+        utils.settle(resolve, reject, makeResponse(result, config), mockAdapter.delayResponse, responseInterceptors);
       } else {
         result.then(
           function(result) {
-            utils.settle(resolve, reject, makeResponse(result, config), mockAdapter.delayResponse);
+            utils.settle(resolve, reject, makeResponse(result, config), mockAdapter.delayResponse, responseInterceptors);
           },
           function(error) {
             if (mockAdapter.delayResponse > 0) {
@@ -78,7 +80,8 @@ function handleRequest(mockAdapter, resolve, reject, config) {
         status: 404,
         config: config
       },
-      mockAdapter.delayResponse
+      mockAdapter.delayResponse,
+      responseInterceptors
     );
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,20 +83,24 @@ function purgeIfReplyOnce(mock, handler) {
   });
 }
 
-function settle(resolve, reject, response, delay, responseInterceptors = []) {
+function settle(resolve, reject, response, delay, responseInterceptors) {
   if (delay > 0) {
     setTimeout(function() {
       settle(resolve, reject, response, 0, responseInterceptors);
     }, delay);
     return;
   }
+  var respInterceptors = responseInterceptors;
+  if (!respInterceptors) respInterceptors = [];
   if (response.config && response.config.validateStatus) {
     response.config.validateStatus(response.status)
-      ? resolve(responseInterceptors.handlers.reduce((resp, interceptor) => interceptor.fulfilled(resp), response))
+      ? resolve(respInterceptors.handlers.reduce(function(resp, interceptor) {
+        return interceptor.fulfilled(resp);
+      }, response))
       : reject(createErrorResponse(
-      'Request failed with status code ' + response.status,
-      response.config,
-      responseInterceptors.handlers.reduce((resp, interceptor) => interceptor.rejected(resp), response)
+        'Request failed with status code ' + response.status,
+        response.config,
+        response
       ));
     return;
   }

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -705,7 +705,9 @@ describe('MockAdapter basics', function() {
   it('supports a retry', function() {
     mock.onGet('/').replyOnce(401);
     mock.onGet('/').replyOnce(201);
-    instance.interceptors.response.use(undefined, function(error) {
+    instance.interceptors.response.use(function(response) {
+      return response;
+    }, function(error) {
       if (error.response && error.response.status === 401) {
         return instance(error.config);
       }


### PR DESCRIPTION
Currently axios mock adapter foregoes any response interceptors defined on the axios instance.

This is contrary to the documentation in axios on how adapters should behave. It says that response interceptors should be called once the response has settled.

See here:
https://github.com/axios/axios/tree/master/lib/adapters

`    // From here:
    //  - response transformers will run
    //  - response interceptors will run`

This implementation I provided will call the appropriate interceptors implemented on the original axios instance, bringing the mock adapter more in line with how axios describes adapters should work.

I needed this on my client because I'm using an interceptor on the axios instance that only returns reponse.data to the view model instead of the whole response object because the view shouldn't care about any networking or whereever else the data comes from.