### PR TITLE
Implement redirect mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ var MockAdapter = require('axios-mock-adapter');
 // This sets the mock adapter on the default instance
 var mock = new MockAdapter(axios);
 
-// Mock GET request to /users when param `searchText` is 'John' 
+// Mock GET request to /users when param `searchText` is 'John'
 // arguments for reply are (status, data, headers)
 mock.onGet('/users', { params: { searchText: 'John' } }).reply(200, {
   users: [
@@ -114,6 +114,14 @@ mock.onGet('/users').reply(function(config) {
       { id: 1, name: 'John Smith' }
     ]
   }];
+});
+```
+
+Passing a function to `reply` that returns an axios request, essentially mocking a redirect
+
+```js
+mock.onPost('/foo').reply(function(config) {
+  return axios.get('/bar');
 });
 ```
 

--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -55,7 +55,11 @@ function handleRequest(mockAdapter, resolve, reject, config) {
       } else {
         result.then(
           function(result) {
-            utils.settle(resolve, reject, makeResponse(result, config), mockAdapter.delayResponse);
+            if (result.config && result.status) {
+              utils.settle(resolve, reject, makeResponse([result.status, result.data, result.headers], result.config), 0);
+            } else {
+              utils.settle(resolve, reject, makeResponse(result, config), mockAdapter.delayResponse);
+            }
           },
           function(error) {
             if (mockAdapter.delayResponse > 0) {

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -78,6 +78,20 @@ describe('MockAdapter basics', function() {
     });
   });
 
+  it('accepts a callback that returns an axios request', function() {
+    mock
+      .onGet('/bar').reply(200, { foo: 'bar' })
+      .onGet('/foo').reply(function() {
+        return instance.get('/bar')
+      });
+
+    return instance.get('/foo').then(function(response) {
+      expect(response.status).to.equal(200);
+      expect(response.config.url).to.equal('/bar');
+      expect(response.data.foo).to.equal('bar');
+    });
+  });
+
   it('matches on a regex', function() {
     mock.onGet(/\/fo+/).reply(200);
 


### PR DESCRIPTION
This PR adds the ability to return an axios request in a `reply` callback function, essentially mocking a redirect:

```javascript
mock
  .onGet('/bar').reply(200, { foo: 'bar' })
  .onGet('/foo').reply(function() {
    return axios.get('/bar')
  });

axios.get('/foo')
  .then(function(response) {
    console.log(response.data); // { foo: 'bar' }
    console.log(response.config.url); // "/bar"
  });
```

This closes #145. 