### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Composing from multiple sources with Promises:
 ```js
 var normalAxios = axios.create();
 var mockAxios = axios.create();
-var mock = MockAdapter(mockAxios);
+var mock = new MockAdapter(mockAxios);
 
 mock
   .onGet('/orders')


### PR DESCRIPTION
The `new` operator seems to be missing here to properly instantiate the `mockAdapter` in the example *Composing from multiple sources with Promises*