### PR TITLE
Add list as an http verb

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ var deepEqual = require('deep-equal');
 
 var handleRequest = require('./handle_request');
 
-var VERBS = ['get', 'post', 'head', 'delete', 'patch', 'put', 'options'];
+var VERBS = ['get', 'post', 'head', 'delete', 'patch', 'put', 'options', 'list'];
 
 function adapter() {
   return function(config) {


### PR DESCRIPTION
There are some services that expose an HTTP API that use the unofficial verb 'LIST' (e.g. HashiCorp Vault).  Testing integration with these services is currently impossible with this library.  While LIST is an unofficial HTTP verb, I don't see any reason to not include it so that consumers of axios-mock-adapter can use it everywhere they need to.  