### PR TITLE
add support for asymmetric matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Mock a low level network error
 // Returns a failed promise with Error('Network Error');
 mock.onGet('/users').networkError();
 
-// networkErrorOnce can be used to mock a network error only once 
+// networkErrorOnce can be used to mock a network error only once
 mock.onGet('/users').networkErrorOnce();
 ```
 
@@ -110,7 +110,7 @@ Mock a network timeout
 // Returns a failed promise with Error with code set to 'ECONNABORTED'
 mock.onGet('/users').timeout();
 
-// timeoutOnce can be used to mock a timeout only once 
+// timeoutOnce can be used to mock a timeout only once
 mock.onGet('/users').timeoutOnce();
 ```
 
@@ -221,6 +221,24 @@ Mocking a request with a specific request body/data
 
 ```js
 mock.onPut('/product', { id: 4, name: 'foo' }).reply(204);
+```
+
+Using an asymmetric matcher, for example Jest matchers
+
+```js
+mock.onPost('/product', { id: 1 }, expect.objectContaining({
+  'Authorization': expect.stringMatching(/^Basic /)
+})).reply(204);
+```
+
+Using a custom asymmetric matcher (any object that has a `asymmetricMatch` property)
+
+```js
+mock.onPost('/product', {
+  asymmetricMatch: function(actual) {
+    return ['computer', 'phone'].includes(actual['type']);
+  }
+}).reply(204);
 ```
 
 `.passThrough()` forwards the matched request over network

--- a/test/asymmetric.spec.js
+++ b/test/asymmetric.spec.js
@@ -1,0 +1,42 @@
+var axios = require('axios');
+var expect = require('chai').expect;
+
+var MockAdapter = require('../src');
+
+describe('MockAdapter asymmetric matchers', function() {
+  var instance;
+  var mock;
+
+  beforeEach(function() {
+    instance = axios.create();
+    mock = new MockAdapter(instance);
+  });
+
+  it('mocks a post request with a body matching the matcher', function() {
+    mock.onPost('/anyWithBody', {
+      asymmetricMatch: function(actual) {
+        return actual.params === '1';
+      }
+    }).reply(200);
+
+    return instance
+      .post('/anyWithBody', { params: '1' })
+      .then(function(response) {
+        expect(response.status).to.equal(200);
+      });
+  });
+
+  it('mocks a post request with a body not matching the matcher', function() {
+    mock.onPost('/anyWithBody', {
+      asymmetricMatch: function(actual) {
+        return actual.params === '1';
+      }
+    }).reply(200);
+
+    return instance
+      .post('/anyWithBody', { params: '2' })
+      .catch(function(error) {
+        expect(error.message).to.eq('Request failed with status code 404');
+      });
+  });
+});


### PR DESCRIPTION
Instead of requiring an exact match, we can now also allow a partial match when using a matcher. The only requirement for such a matcher is that it has a `asymmetricMatch` method, which is the case for certain Jest and Jasmine matchers.

An example using a Jest matcher;

```js
mock.onPost(
  'http://foobar.com/baz',
  { user_id: 10 },
  expect.objectContaining({
    'Content-Type': 'application/json',
    'test-header': 'test',
  })
).reply(200, { foo: 'bar' });
```

But it also is possible to create a custom matcher:

```js
mock.onPost(
  'http://foobar.com/baz',
  { user_id: 10 },
  {
    asymmetricMatch(actual) {
      return actual['some-header'] === 'foobar';
    }
  }
).reply(200, { foo: 'bar' });
```

Fixes #180