### PR TITLE
Add history to typescript definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -48,6 +48,8 @@ declare class MockAdapter {
   adapter(): AxiosAdapter;
   reset(): void;
   restore(): void;
+  
+  history: { [method:string]:AxiosRequestConfig[]; };
 
   onGet: RequestMatcherFunc;
   onPost: RequestMatcherFunc;


### PR DESCRIPTION
The history feature isn't available for type script users at the moment.
I added the history attribute to the typescript definition.