### PR TITLE
Request failed error message improvement

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -95,7 +95,7 @@ function settle(resolve, reject, response, delay) {
     response.config.validateStatus(response.status)
       ? resolve(response)
       : reject(createErrorResponse(
-        'Request failed with status code ' + response.status,
+        response.config.method.toUpperCase() + ' request: ' + response.config.url + ' failed with status code ' + response.status,
         response.config,
         response
       ));

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -388,7 +388,7 @@ describe('MockAdapter basics', function() {
 
     return instance.get('/foo').catch(function(error) {
       expect(error).to.be.an.instanceof(Error);
-      expect(error.message).to.match(/request failed/i);
+      expect(error.message).to.equal('GET request: /foo failed with status code 500');
     });
   });
 


### PR DESCRIPTION
Hi,

in case of request failure a generic error message is returned: "Request failed with status code CODE". Without the URL and method it is was hard for me to identify the problematic call so I made a small change in the error message and now it contains both the URL and method.