### PR TITLE
Fix axios response interceptor triggered twice (#61)

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -39,7 +39,11 @@ function handleRequest(mockAdapter, resolve, reject, config) {
       // passThrough handler
       // tell axios to use the original adapter instead of our mock, fixes #35
       config.adapter = mockAdapter.originalAdapter;
+      // don't use the transforms because they are called by axios, fixes #61
+      // TODO: write a more elegant solution that isn't turning transforms off and on
+      var transforms = utils.retrieveTransforms(mockAdapter.axiosInstance, config);
       mockAdapter.axiosInstance.request(config).then(resolve, reject);
+      utils.injectTransforms(transforms, mockAdapter.axiosInstance, config);
     } else if (typeof handler[3] !== 'function') {
       utils.settle(
         resolve,

--- a/src/utils.js
+++ b/src/utils.js
@@ -124,10 +124,46 @@ function isSimpleObject(value) {
   return value !== null && value !== undefined && value.toString() === '[object Object]';
 }
 
+function retrieve(obj, prop) {
+  var val = obj[prop];
+  delete obj[prop];
+  return val;
+}
+
+function retrieveTransforms(instance, config) {
+  var requestInterceptors = [];
+  while (instance.interceptors.request.handlers.length) {
+    requestInterceptors.push(instance.interceptors.request.handlers.pop());
+  }
+  var responseInterceptors = [];
+  while (instance.interceptors.response.handlers.length) {
+    responseInterceptors.push(instance.interceptors.response.handlers.pop());
+  }
+  return {
+    requestInterceptors: requestInterceptors,
+    responseInterceptors: responseInterceptors,
+    transformRequest: retrieve(config, 'transformRequest'),
+    transformResponse: retrieve(config, 'transformResponse')
+  };
+}
+
+function injectTransforms(transforms, instance, config) {
+  transforms.requestInterceptors.forEach(function(i) {
+    instance.interceptors.request.use(i);
+  });
+  transforms.responseInterceptors.forEach(function(i) {
+    instance.interceptors.response.use(i);
+  });
+  config.transformRequest = transforms.transformRequest;
+  config.transformResponse = transforms.transformResponse;
+}
+
 module.exports = {
   find: find,
   findHandler: findHandler,
   isSimpleObject: isSimpleObject,
   purgeIfReplyOnce: purgeIfReplyOnce,
-  settle: settle
+  settle: settle,
+  retrieveTransforms: retrieveTransforms,
+  injectTransforms: injectTransforms
 };

--- a/test/pass_through.spec.js
+++ b/test/pass_through.spec.js
@@ -109,4 +109,60 @@ describe('passThrough tests (requires Node)', function() {
         })
     ]);
   });
+  it('handles request transformations properly', function() {
+    mock.onGet('/foo').passThrough();
+
+    return instance.get('/foo', {
+      data: 'foo',
+      transformRequest: [function(data) {
+        return data + 'foo';
+      }]
+    })
+      .then(function(response) {
+        expect(response.config.data).to.equal('foofoo');
+      });
+  });
+  it('handles request interceptors properly', function() {
+    instance.interceptors.request.use(function god(req) {
+      if (req.data === 'foofoo') {
+      }
+      req.data += 'foo';
+      return req;
+    }, Promise.reject);
+    mock.onGet('/foo').passThrough();
+
+    return instance.get('/foo', {
+      data: 'foo'
+    })
+      .then(function(response) {
+        expect(response.config.data).to.equal('foofoo');
+      });
+  });
+
+  it('handles response transformations properly', function() {
+    mock.onGet('/foo').passThrough();
+
+    return instance.get('/foo', {
+      transformResponse: [function(data) {
+        return data + 'foo';
+      }]
+    })
+      .then(function(response) {
+        expect(response.data).to.equal('foofoo');
+      });
+  });
+  it('handles response interceptors properly', function() {
+    instance.interceptors.response.use(function(res) {
+      res.data += 'foo';
+      return res;
+    }, Promise.reject);
+    mock.onGet('/foo').passThrough();
+
+    return instance.get('/foo', {
+      data: 'foo'
+    })
+      .then(function(response) {
+        expect(response.data).to.equal('foofoo');
+      });
+  });
 });


### PR DESCRIPTION
Since the transforms and interceptors are running again for `passThrough`, I resolved to removing the handlers when running the request, and adding them back afterwards. 

I don't consider this merge request good, but it works.
I guess it's a hack, but maybe out of need.