### PR TITLE
fix: declare resetHistory method in MockAdapter class

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,9 +47,10 @@ declare class MockAdapter {
 
   adapter(): AxiosAdapter;
   reset(): void;
+  resetHistory(): void;
   restore(): void;
-  
-  history: { [method:string]:AxiosRequestConfig[]; };
+
+  history: { [method: string]: AxiosRequestConfig[] };
 
   onGet: RequestMatcherFunc;
   onPost: RequestMatcherFunc;


### PR DESCRIPTION
Related Issue: #194 