### PR TITLE
【bugfix】call originalAdapter instead of request in passThrough

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -37,9 +37,7 @@ function handleRequest(mockAdapter, resolve, reject, config) {
 
     if (handler.length === 2) {
       // passThrough handler
-      // tell axios to use the original adapter instead of our mock, fixes #35
-      config.adapter = mockAdapter.originalAdapter;
-      mockAdapter.axiosInstance.request(config).then(resolve, reject);
+      mockAdapter.originalAdapter(config).then(resolve, reject);
     } else if (typeof handler[3] !== 'function') {
       utils.settle(
         resolve,


### PR DESCRIPTION
Calling request in passThrough causes interceptor to excute twice