### PR TITLE
Add resetHandlers and resetHistory types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,6 +47,8 @@ declare class MockAdapter {
 
   adapter(): AxiosAdapter;
   reset(): void;
+  resetHandlers(): void;
+  resetHistory(): void;
   restore(): void;
   
   history: { [method:string]:AxiosRequestConfig[]; };

--- a/types/test.ts
+++ b/types/test.ts
@@ -22,6 +22,14 @@ namespace SupportsReset {
   mock.reset();
 }
 
+namespace SupportsResetHandlers {
+  mock.resetHandlers();
+}
+
+namespace SupportsResetHistory {
+  mock.resetHistory();
+}
+
 namespace SupportsRestore {
   mock.restore();
 }


### PR DESCRIPTION
The `mock.resetHandlers` and `mock.resetHistory` properties were missing from the type definitions. This PR adds them!