### PR TITLE
 Fix timeout, timeoutOnce, networkError, networkErrorOnce TS typedefs

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,12 +13,11 @@ type ResponseSpecFunc = (
 interface RequestHandler {
   reply: ResponseSpecFunc;
   replyOnce: ResponseSpecFunc;
-  timeoutOnce: ResponseSpecFunc;
-  networkErrorOnce: ResponseSpecFunc;
-
   passThrough(): MockAdapter;
-  networkError(): MockAdapter;
-  timeout(): MockAdapter;
+  networkError(): void;
+  networkErrorOnce(): void;
+  timeout(): void;
+  timeoutOnce(): void;
 }
 
 interface MockAdapterOptions {


### PR DESCRIPTION
... so they are more aligned with [reality](https://github.com/ctimmerm/axios-mock-adapter/blob/8681af9c8375be4c5dc798f68a90154b5552cadd/src/index.js)