### PR TITLE
Allow using route params

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,48 @@ const url = new RegExp(`${usersUri}/*`);
 mock.onGet(url).reply(200, users);
 ```
 
+Using route params (colon notation)
+
+```js
+const routeParams = {
+  ':userId': '[0-9]{1,8}',
+  ':filter': 'active|inactive|all',
+}
+const mock = new MockAdapter(axios, {}, routeParams);
+
+mock.onGet('/users/:userId/posts/:filter').reply(function(config) {
+  const { userId, filter } = config.routeParams;
+  
+  // userId === '123'
+  // filter === 'active'
+
+  return [200, {}];
+});
+
+axios.get('/users/123/posts/active');
+```
+
+Using route params (curly braces notation)
+
+```js
+const routeParams = {
+  '{uuid}': '[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}',
+  '{page}': '\\d?',
+}
+const mock = new MockAdapter(axios, {}, routeParams);
+
+mock.onGet('/users/{uuid}/posts/{page}').reply(function(config) {
+  const { uuid, page } = config.routeParams;
+  
+  // uuid === 'b67c0749-656c-4beb-9cd9-17e274a648d9'
+  // page === '3'
+
+  return [200, {}];
+});
+
+axios.get('/users/b67c0749-656c-4beb-9cd9-17e274a648d9/posts/3');
+```
+
 
 Specify no path to match by verb alone
 

--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -31,9 +31,10 @@ function handleRequest(mockAdapter, resolve, reject, config) {
   );
 
   if (handler) {
-    if (handler.length === 7) {
+    if (handler.length === 8) {
       utils.purgeIfReplyOnce(mockAdapter, handler);
     }
+    config.routeParams = utils.getRouteParams(mockAdapter.knownRouteParams, handler[6], config);
 
     if (handler.length === 2) {
       // passThrough handler

--- a/src/utils.js
+++ b/src/utils.js
@@ -124,10 +124,45 @@ function isSimpleObject(value) {
   return value !== null && value !== undefined && value.toString() === '[object Object]';
 }
 
+function getRouteParams(knownRouteParams, route, config) {
+  var routeParams = {}
+
+  if (knownRouteParams == null || typeof route !== 'string') {
+    return routeParams;
+  }
+
+  var paramsUsedInRoute = route.split('/').filter(function (param) {
+    return knownRouteParams[param] !== undefined;
+  });
+  if (paramsUsedInRoute.length == 0) {
+    return routeParams;
+  }
+
+  paramsUsedInRoute.forEach(function(param) {
+    route = route.replace(param, '(' + knownRouteParams[param] + ')');
+  });
+
+  var actualUrl = config.baseURL ? config.url.slice(config.baseURL.length) : config.url;
+  var routeMatches = actualUrl.match(new RegExp('^' + route + '$'));
+
+  paramsUsedInRoute.forEach(function(param, index) {
+    var paramNameMatches = param.match(/^:(.+)|{(.+)}$/) || [];
+    var paramName = paramNameMatches[1] || paramNameMatches[2];
+    if (paramName === undefined) {
+      return;
+    }
+
+    routeParams[paramName] = routeMatches[index+1];
+  })
+
+  return routeParams;
+}
+
 module.exports = {
   find: find,
   findHandler: findHandler,
   isSimpleObject: isSimpleObject,
   purgeIfReplyOnce: purgeIfReplyOnce,
-  settle: settle
+  settle: settle,
+  getRouteParams: getRouteParams,
 };

--- a/test/route_params.spec.js
+++ b/test/route_params.spec.js
@@ -1,0 +1,162 @@
+var axios = require('axios');
+var expect = require('chai').expect;
+
+var MockAdapter = require('../src');
+
+describe('MockAdapter route params', function() {
+  var instance;
+  var mock;
+
+  it('matches route with params', function() {
+    var routeParams = {
+      ':userUuid': '[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}',
+      ':filter': '((active)|inactive|all)',
+    }
+
+    instance = axios.create();
+    mock = new MockAdapter(instance, {}, routeParams);
+
+    expect(mock.knownRouteParams).to.deep.equal(routeParams);
+
+    mock.onGet('/users/:userUuid/posts/:filter').reply(200, 'body');
+
+    return instance.get('/users/b67c0749-656c-4beb-9cd9-17e274a648d9/posts/active').then(function(response) {
+      expect(response.status).to.equal(200);
+    });
+  });
+
+  it('rejects route when params regex does not match', function() {
+    var routeParams = {
+      ':userUuid': '[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}',
+      ':filter': 'active|inactive|all',
+    }
+
+    instance = axios.create();
+    mock = new MockAdapter(instance, {}, routeParams);
+
+    expect(mock.knownRouteParams).to.deep.equal(routeParams);
+
+    mock.onGet('/users/:userUuid/posts/:filter').reply(200, 'body');
+
+    return instance.get('/users/all/posts/recent').catch(function(error) {
+      expect(error.response.status).to.equal(404);
+      expect(error.response.config.routeParams).to.equal(undefined);
+    });
+  });
+
+  it('matches route with params and makes params available on config', function() {
+    var routeParams = {
+      ':userUuid': '[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}',
+      ':filter': '.+',
+    }
+
+    instance = axios.create();
+    mock = new MockAdapter(instance, {}, routeParams);
+
+    expect(mock.knownRouteParams).to.deep.equal(routeParams);
+
+    mock.onGet('/users/:userUuid/posts/:filter').reply(function(config) {
+      expect(config.routeParams).to.deep.equal({
+        'userUuid': 'b67c0749-656c-4beb-9cd9-17e274a648d9',
+        'filter': 'inactive'
+      });
+      return [200, 'body'];
+    });
+
+    return instance.get('/users/b67c0749-656c-4beb-9cd9-17e274a648d9/posts/inactive').then(function(response) {
+      expect(response.status).to.equal(200);
+    });
+  });
+
+  it('matches route with params when using baseURL', function() {
+    var routeParams = {
+      ':userId': '\\d+',
+      ':filter': 'active|inactive|all',
+    }
+
+    instance = axios.create();
+    instance.defaults.baseURL = 'http://www.example.org/api/v1';
+    mock = new MockAdapter(instance, {}, routeParams);
+
+    expect(mock.knownRouteParams).to.deep.equal(routeParams);
+
+    mock.onGet('/users/:userId/posts/:filter').reply(function(config) {
+      expect(config.routeParams).to.deep.equal({
+        'userId': '123',
+        'filter': 'inactive'
+      });
+      return [200, 'body'];
+    });
+
+    return instance.get('/users/123/posts/inactive').then(function(response) {
+      expect(response.status).to.equal(200);
+    });
+  });
+
+  it('matches route with params when using curly braces', function() {
+    var routeParams = {
+      '{userId}': '\\d+',
+      '{filter}': 'active|inactive|all',
+    }
+
+    instance = axios.create();
+    mock = new MockAdapter(instance, {}, routeParams);
+
+    expect(mock.knownRouteParams).to.deep.equal(routeParams);
+
+    mock.onGet('/users/{userId}/posts/{filter}/orderby:date:desc').reply(function(config) {
+      expect(config.routeParams).to.deep.equal({
+        'userId': '123',
+        'filter': 'inactive'
+      });
+      return [200, 'body'];
+    });
+
+    return instance.get('/users/123/posts/inactive/orderby:date:desc').then(function(response) {
+      expect(response.status).to.equal(200);
+    });
+  });
+
+  it('does not match params when param keys are not using colons or curly braces notation', function() {
+    var routeParams = {
+      'userId': '\\d+',
+      'filter': 'active|inactive|all',
+    }
+
+    instance = axios.create();
+    mock = new MockAdapter(instance, {}, routeParams);
+
+    expect(mock.knownRouteParams).to.deep.equal(null);
+
+    mock.onGet('/users/userId/posts/filter').reply(function(config) {
+      expect(config.routeParams).to.deep.equal({});
+      return [200, 'body'];
+    });
+
+    return instance.get('/users/123/posts/inactive').catch(function(error) {
+      expect(error.response.status).to.equal(404);
+      expect(error.response.config.routeParams).to.equal(undefined);
+    });
+  });
+
+  it('does not use known route params when matcher is not a string', function() {
+    var routeParams = {
+      ':userId': '\\d+',
+      ':filter': 'active|inactive|all',
+    }
+
+    instance = axios.create();
+    mock = new MockAdapter(instance, {}, routeParams);
+
+    expect(mock.knownRouteParams).to.deep.equal(routeParams);
+
+    mock.onGet(/\/users\/\d+\/posts\/active|inactive|all/).reply(function(config) {
+      expect(config.routeParams).to.deep.equal({});
+      return [200, 'body'];
+    });
+
+    return instance.get('/users/123/posts/inactive').then(function(response) {
+      expect(response.status).to.equal(200);
+    });
+  });
+});


### PR DESCRIPTION
Working with route params is more convenient than defining the regex in the matcher itself (avoids duplication of regexes for similar routes, allows using the same routes you have on the backend or in the API spec etc.)

This implementation:
* allows configuring a set of known route params as the 3rd argument to the constructor
* exposes the values for the params on matched routes under `config.routeParams`
* allows using both colon (`:userId`) and curly braces (`{userId}`) for route params


Example using the colon notation:

```js
const routeParams = {
  ':userId': '[0-9]{1,8}',
  ':filter': 'active|inactive|all',
}
const mock = new MockAdapter(axios, {}, routeParams);

mock.onGet('/users/:userId/posts/:filter').reply(function(config) {
  const { userId, filter } = config.routeParams;
  
  // userId === '123'
  // filter === 'active'

  return [200, {}];
});

axios.get('/users/123/posts/active');
```

Example using the curly braces notation:

```js
const routeParams = {
  '{uuid}': '[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}',
  '{page}': '\\d?',
}
const mock = new MockAdapter(axios, {}, routeParams);

mock.onGet('/users/{uuid}/posts/{page}').reply(function(config) {
  const { uuid, page } = config.routeParams;
  
  // uuid === 'b67c0749-656c-4beb-9cd9-17e274a648d9'
  // page === '3'

  return [200, {}];
});

axios.get('/users/b67c0749-656c-4beb-9cd9-17e274a648d9/posts/3');
```


This addresses requests from https://github.com/ctimmerm/axios-mock-adapter/issues/199 and https://github.com/ctimmerm/axios-mock-adapter/issues/82