### PR TITLE
Added ability to passThrough() if its set at beginning of all handlers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -151,18 +151,34 @@ function findInHandlers(method, handlers, handler) {
 }
 
 function addHandler(method, handlers, handler) {
-  if (method === 'any') {
-    VERBS.forEach(function(verb) {
-      handlers[verb].push(handler);
-    });
-  } else {
-    var indexOfExistingHandler = findInHandlers(method, handlers, handler);
-    if (indexOfExistingHandler > -1 && handler.length < 7) {
-      handlers[method].splice(indexOfExistingHandler, 1, handler);
-    } else {
-      handlers[method].push(handler);
-    }
-  }
+	const passThroughHandler = [/.*/, undefined]
+
+	if (method === 'any') {
+		VERBS.forEach(function(verb) {
+			handlers[verb].push(handler)
+		})
+	} else {
+		var indexOfExistingHandler = findInHandlers(method, handlers, handler)
+
+		if (indexOfExistingHandler > -1 && handler.length < 7) {
+			handlers[method].splice(indexOfExistingHandler, 1, handler)
+		} else {
+			const methodHandlersLength = handlers[method].length
+			const lastHandlerPosition = methodHandlersLength - 1
+			const lastHandler = handlers[method][lastHandlerPosition]
+
+			if (lastHandlerPosition < 0) {
+				handlers[method].push(handler)
+			} else {
+				if (`${lastHandler[0]}` === '/.*/') {
+					handlers[method][lastHandlerPosition] = handler
+					handlers[method].push(passThroughHandler)
+				} else {
+					handlers[method].push(handler)
+				}
+			}
+		}
+	}
 }
 
 module.exports = MockAdapter;

--- a/test/pass_through.spec.js
+++ b/test/pass_through.spec.js
@@ -83,6 +83,33 @@ describe('passThrough tests (requires Node)', function() {
       });
   });
 
+  it('allows setting passThrough handler at beginning', function() {
+    mock
+      .onAny()
+      .passThrough();
+
+    mock
+      .onGet('/foo')
+      .reply(200, 'bar')
+
+    var randomPath = 'xyz' + Math.round(10000 * Math.random());
+
+    return Promise.all([
+      instance.get('/foo').then(function(response) {
+        expect(response.status).to.equal(200);
+        expect(response.data).to.equal('bar');
+      }),
+      instance.get('/' + randomPath).then(function(response) {
+        expect(response.status).to.equal(200);
+        expect(response.data).to.equal('/' + randomPath);
+      }),
+      instance.post('/post').then(function(response) {
+        expect(response.status).to.equal(200);
+        expect(response.data).to.equal('/post');
+      })
+    ]);
+  });
+
   it('allows setting default passThrough handler', function() {
     mock
       .onGet('/foo')


### PR DESCRIPTION
Example of a problem:
```js
const mock = new MockAdapter(instance)
mock.onAny().passThrough()

mock
    .onGet('/foo')
    .reply(200, 'bar')

mock
    .onGet('/bar')
    .reply(200, 'foo')

```

In this case every request will be forwarded to origin instance.

According to the documentation you need to do this:
```js
const mock = new MockAdapter(instance)

mock
    .onGet('/foo')
    .reply(200, 'bar')

mock
    .onGet('/bar')
    .reply(200, 'foo')

mock.onAny().passThrough()
```

But this is inconvenient, because the code can be in different files and run out of order. This PR fixes this.