### PR TITLE
relaxing headers check to allow partial matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ axios.get('/users', { params: { searchText: 'John' } } )
   });
 ```
 
+Mocking a `POST` request with specifying headers that must be present among request headers(but all extra request headers are ignored):
+
+```js
+var axios = require('axios');
+var MockAdapter = require('axios-mock-adapter');
+
+// This sets the mock adapter on the default instance
+var mock = new MockAdapter(axios);
+
+// Mock POST request to /users when request headers contain 'Content-Type': 'application/json'
+// arguments for reply are (status, data, headers)
+mock.onPost('/users', undefined, {'Content-Type': 'application/json'}).reply(200, {
+  users: [
+    { id: 1, name: 'John Smith' }
+  ]
+});
+
+axios.post('/users', undefined, { headers: { 'Content-Type': 'application/json', Accept: 'application/json' } })
+  .then(function(response) {
+    console.log(response.data);
+  });
+
+```
+
 To add a delay to responses, specify a delay amount (in milliseconds) when instantiating the adapter
 
 ```js

--- a/src/utils.js
+++ b/src/utils.js
@@ -44,7 +44,7 @@ function isUrlMatching(url, required) {
 
 function isRequestHeadersMatching(requestHeaders, required) {
   if (required === undefined) return true;
-  return isEqual(requestHeaders, required);
+  return containsHeaders(required, requestHeaders);
 }
 
 function isBodyOrParametersMatching(method, body, parameters, required) {
@@ -122,6 +122,15 @@ function createErrorResponse(message, config, response) {
 
 function isSimpleObject(value) {
   return value !== null && value !== undefined && value.toString() === '[object Object]';
+}
+
+function containsHeaders(reference, target) {
+  console.log(reference, target);
+  if (!reference || !target) return deepEqual(reference, target);
+  if (typeof reference !== 'object' || typeof target !== 'object') return deepEqual(reference, target);
+  return Object.keys(reference).every(function(index) {
+    return deepEqual(reference[index], target[index]);
+  });
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -125,7 +125,6 @@ function isSimpleObject(value) {
 }
 
 function containsHeaders(reference, target) {
-  console.log(reference, target);
   if (!reference || !target) return deepEqual(reference, target);
   if (typeof reference !== 'object' || typeof target !== 'object') return deepEqual(reference, target);
   return Object.keys(reference).every(function(index) {

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -264,12 +264,11 @@ describe('MockAdapter basics', function() {
 
   it('can pass headers to match to a handler', function() {
     var headers = {
-      Accept: 'application/json, text/plain, */*',
       'Content-Type': 'application/x-www-form-urlencoded',
       'Header-test': 'test-header'
     };
 
-    mock.onPost('/withHeaders', undefined, headers).reply(200);
+    mock.onPost('/withHeaders', undefined, { 'Header-test': 'test-header' }).reply(200);
 
     return instance
       .post('/withHeaders', undefined, { headers: headers })
@@ -285,6 +284,19 @@ describe('MockAdapter basics', function() {
     return instance
       .patch('/wrongObjHeader', undefined, {
         headers: { 'Header-test': 'wrong-header' }
+      })
+      .catch(function(error) {
+        expect(error.response.status).to.equal(404);
+      });
+  });
+
+  it('does not match when some required headers is missing on request', function() {
+    var headers = { 'Header-test': 'test-header', 'Header-test2': 'test-header2' };
+    mock.onPatch('/wrongObjHeader', undefined, headers).reply(200);
+
+    return instance
+      .patch('/wrongObjHeader', undefined, {
+        headers: { 'Header-test': 'test-header' }
       })
       .catch(function(error) {
         expect(error.response.status).to.equal(404);


### PR DESCRIPTION
Allowing mock match if request contains extra headers not specified in mock explicitly.
https://github.com/ctimmerm/axios-mock-adapter/issues/219
https://github.com/ctimmerm/axios-mock-adapter/issues/214