### PR TITLE
change any to generic type variable

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,9 +4,9 @@ type CallbackResponseSpecFunc = (
   config: AxiosRequestConfig
 ) => any[] | Promise<any[]>;
 
-type ResponseSpecFunc = (
+type ResponseSpecFunc = <T = any>(
   statusOrCallback: number | CallbackResponseSpecFunc,
-  data?: any,
+  data?: T,
   headers?: any
 ) => MockAdapter;
 


### PR DESCRIPTION
Changed the type of `data` in `ResponseSpecFunc` to `<T = any>`.
With this change, guarantees the type of `data`.