### PR TITLE
Extend history to include handler information.

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -21,7 +21,6 @@ function handleRequest(mockAdapter, resolve, reject, config) {
   }
 
   delete config.adapter;
-  mockAdapter.history[config.method].push(config);
 
   var handler = utils.findHandler(
     mockAdapter.handlers,
@@ -32,6 +31,12 @@ function handleRequest(mockAdapter, resolve, reject, config) {
     config.headers,
     config.baseURL
   );
+
+  mockAdapter.history[config.method].push(Object.assign(config, {
+    handler: {
+      passThrough: handler && handler.length === 2
+    }
+  }));
 
   if (handler) {
     if (handler.length === 7) {

--- a/test/history.spec.js
+++ b/test/history.spec.js
@@ -27,6 +27,7 @@ describe('MockAdapter history', function() {
         expect(mock.history.get.length).to.equal(1);
         expect(mock.history.get[0].method).to.equal('get');
         expect(mock.history.get[0].url).to.equal('/foo');
+        expect(mock.history.get[0].handler.passThrough).to.equal(false);
       });
   });
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,10 @@ type ResponseSpecFunc = <T = any>(
   headers?: any
 ) => MockAdapter;
 
+type RequestHandlerInfo = {
+  passThrough: boolean
+}
+
 interface RequestHandler {
   reply: ResponseSpecFunc;
   replyOnce: ResponseSpecFunc;
@@ -50,7 +54,9 @@ declare class MockAdapter {
   resetHistory(): void;
   restore(): void;
 
-  history: { [method: string]: AxiosRequestConfig[] };
+  history: { [method: string]: AxiosRequestConfig & {
+    handler: RequestHandlerInfo
+  }[] };
 
   onGet: RequestMatcherFunc;
   onPost: RequestMatcherFunc;


### PR DESCRIPTION
Currently the history only contains the requests sent to axios it doesn't have any information about how that request was handled. I would have liked to just include the handler but it requires a lot of interpretation. This model can be extended in the future to include additional fields if they are useful for others.