### PR TITLE
Implement requestAborted function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,30 @@ VERBS.concat('any').forEach(function(method) {
         return _this;
       },
 
+      requestAborted: function() {
+        reply(function(config) {
+          var error = utils.createAxiosError(
+            'Request aborted',
+            config,
+            undefined,
+            'ECONNABORTED'
+          );
+          return Promise.reject(error);
+        });
+      },
+
+      requestAbortedOnce: function() {
+        replyOnce(function(config) {
+          var error = utils.createAxiosError(
+            'Request aborted',
+            config,
+            undefined,
+            'ECONNABORTED'
+          );
+          return Promise.reject(error);
+        });
+      },
+
       networkError: function() {
         reply(function(config) {
           var error = utils.createAxiosError('Network Error', config);

--- a/test/request_aborted.spec.js
+++ b/test/request_aborted.spec.js
@@ -1,0 +1,32 @@
+var axios = require('axios');
+var expect = require('chai').expect;
+
+var MockAdapter = require('../src');
+
+describe('requestAborted spec', function() {
+  var mock;
+
+  beforeEach(function() {
+    mock = new MockAdapter(axios);
+  });
+
+  afterEach(function() {
+    mock.restore();
+  });
+
+  it('mocks requestAborted response', function() {
+    mock.onGet('/foo').requestAborted();
+
+    return axios.get('/foo').then(
+      function() {
+        expect.fail('should not be called');
+      },
+      function(error) {
+        expect(error.config).to.exist;
+        expect(error.code).to.equal('ECONNABORTED');
+        expect(error.message).to.equal('Request aborted');
+        expect(error.isAxiosError).to.be.true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
This PR implement mock function that returns `Request aborted` error. Its error is called in https://github.com/axios/axios/blob/dc4bc49673943e35280e5df831f5c3d0347a9393/lib/adapters/xhr.js#L73 .