### PR TITLE
fix for IE11

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,7 @@
 var axios = require("axios");
 var isEqual = require("fast-deep-equal");
 var isBuffer = require("is-buffer");
+var toString = Object.prototype.toString;
 
 // < 0.13.0 will not have default headers set on a custom instance
 var rejectWithError = !!axios.create().defaults.headers;


### PR DESCRIPTION
fix toString.call not working in IE11
https://github.com/ctimmerm/axios-mock-adapter/issues/260