### PR TITLE
Create onNoMatch=throwException option to throw exception when could not find mock for requested url

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,24 @@ var mock = new MockAdapter(axiosInstance, { onNoMatch: "passthrough" });
 mock.onAny("/foo").reply(200);
 ```
 
+Using `onNoMatch` option with `throwException` to throw an exception when a request is made without match any handler. It's helpful to debug your test mocks.
+
+```js
+var mock = new MockAdapter(axiosInstance, { onNoMatch: "throwException" });
+
+mock.onAny("/foo").reply(200);
+
+axios.get("/unexistent-path");
+
+// Exception message on console:
+//
+// Could not find mock for: 
+// {
+//   "method": "get",
+//   "url": "http://localhost/unexistent-path"
+// }
+```
+
 As of 1.7.0, `reply` function may return a Promise:
 
 ```js

--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -120,6 +120,8 @@ function handleRequest(mockAdapter, resolve, reject, config) {
       case "passthrough":
         mockAdapter.originalAdapter(config).then(resolve, reject);
         break;
+      case 'throwException':
+        throw utils.createCouldNotFindMockError(config);
       default:
         utils.settle(
           resolve,

--- a/src/utils.js
+++ b/src/utils.js
@@ -97,7 +97,7 @@ function isBodyMatching(body, requiredBody) {
   var parsedBody;
   try {
     parsedBody = JSON.parse(body);
-  } catch (e) {}
+  } catch (e) { }
 
   return isObjectMatching(parsedBody ? parsedBody : body, requiredBody);
 }
@@ -156,6 +156,15 @@ function createAxiosError(message, config, response, code) {
   return error;
 }
 
+function createCouldNotFindMockError(config) {
+  var message = "Could not find mock for: \n" + JSON.stringify(config, ['method', 'url'], 2);
+  var error = new Error(message);
+  error.isCouldNotFindMockError = true;
+  error.url = config.url;
+  error.method = config.method;
+  return error;
+}
+
 module.exports = {
   find: find,
   findHandler: findHandler,
@@ -168,4 +177,5 @@ module.exports = {
   isBuffer: isBuffer,
   isEqual: isEqual,
   createAxiosError: createAxiosError,
+  createCouldNotFindMockError: createCouldNotFindMockError
 };

--- a/test/throw_exception_on_no_match.js
+++ b/test/throw_exception_on_no_match.js
@@ -1,0 +1,50 @@
+var axios = require("axios");
+var expect = require("chai").expect;
+
+var MockAdapter = require("../src");
+
+describe("onNoMatch=throwException option tests (requires Node)", function () {
+  var instance;
+  var mock;
+
+  beforeEach(function () {
+    instance = axios.create();
+    mock = new MockAdapter(instance, { onNoMatch: "throwException" });
+  });
+
+  it("allows selective mocking", function () {
+    mock.onGet("/foo").reply(200, "bar");
+    mock.onGet("/error").reply(200, "success");
+
+    return Promise.all([
+      instance.get("/foo").then(function (response) {
+        expect(response.status).to.equal(200);
+        expect(response.data).to.equal("bar");
+      }),
+      instance.get("/error").then(function (response) {
+        expect(response.status).to.equal(200);
+        expect(response.data).to.equal("success");
+      }),
+    ]);
+  });
+
+  it("handles errors correctly when could not find mock for requested url", function () {
+    var expectedUrl = 'http://127.0.0.1/unexistent_path';
+    var expectedMethod = "get";
+
+    return instance
+      .get(expectedUrl)
+      .then(function () {
+        // The server should've returned an error
+        expect(false).to.be.true;
+      })
+      .catch(function (error) {
+        expect(error).to.have.nested.property("isCouldNotFindMockError", true);
+        expect(error).to.have.nested.property("method", expectedMethod);
+        expect(error).to.have.nested.property("url", expectedUrl);
+        expect(error.message).to.contain("Could not find mock for");
+        expect(error.message).to.contain(expectedMethod);
+        expect(error.message).to.contain(expectedUrl);
+      });
+  });
+});


### PR DESCRIPTION
This submission allows the new option `throwException` in `onNoMatch` instance configuration.

**Current problem:**
When a request has no configured mock, is not possible to trace and identify the source of request. 

This is the only one feedback received from axios-mock-adapter:

```bash
 Request failed with status code 404
    at createAxiosError (node_modules/axios-mock-adapter/src/utils.js:144:19)
    at Object.settle (node_modules/axios-mock-adapter/src/utils.js:124:22)
    at handleRequest (node_modules/axios-mock-adapter/src/handle_request.js:127:15)
```
**Proposed solution**
Using `onNoMatch` option with `throwException` to throw an exception with details about request url and method when a request is made without match any handler.

This is the new console output:

```bash
Could not find mock for: 
{
  "method": "get",
  "url": "http://localhost/unexistent-path"
}
```

I believe this new option is helpful for developers who are working with a lot of mocks. Sometimes we forget to define a required mock or do mistakes when setup it. When it happens, is not possible to trace and identify the source of request.

The same need was mentioned in issue https://github.com/ctimmerm/axios-mock-adapter/issues/173 by @createthis
