### PR TITLE
Set request object on axios errors

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -148,6 +148,9 @@ function createAxiosError(message, config, response, code) {
   var error = new Error(message);
   error.isAxiosError = true;
   error.config = config;
+  error.request = {
+    responseUrl: config.url,
+  };
   if (response !== undefined) {
     error.response = response;
   }

--- a/test/abort_request.spec.js
+++ b/test/abort_request.spec.js
@@ -28,6 +28,7 @@ describe("requestAborted spec", function () {
         expect(error.code).to.equal("ECONNABORTED");
         expect(error.message).to.equal("Request aborted");
         expect(error.isAxiosError).to.be.true;
+        expect(error.request.responseUrl).to.equal("/foo");
       }
     );
   });

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -847,4 +847,17 @@ describe("MockAdapter basics", function () {
         expect(error.isAxiosError).to.be.true;
       });
   });
+
+  it("sets the original request url in the response.request.responseUrl property on errors", function () {
+    mock.onGet("/foo").reply(404);
+
+    return instance
+      .get("/foo")
+      .then(function () {
+        expect(true).to.be.false;
+      })
+      .catch(function (error) {
+        expect(error.request.responseUrl).to.equal("/foo");
+      });
+  });
 });

--- a/test/network_error.spec.js
+++ b/test/network_error.spec.js
@@ -24,6 +24,7 @@ describe("networkError spec", function () {
         expect(error.response).to.not.exist;
         expect(error.message).to.equal("Network Error");
         expect(error.isAxiosError).to.be.true;
+        expect(error.request.responseUrl).to.equal("/foo");
       }
     );
   });

--- a/test/timeout.spec.js
+++ b/test/timeout.spec.js
@@ -24,6 +24,7 @@ describe("timeout spec", function () {
         expect(error.code).to.equal("ECONNABORTED");
         expect(error.message).to.equal("timeout of 0ms exceeded");
         expect(error.isAxiosError).to.be.true;
+        expect(error.request.responseUrl).to.equal("/foo");
       }
     );
   });
@@ -61,6 +62,7 @@ describe("timeout spec", function () {
           expect(error.code).to.equal("ECONNABORTED");
           expect(error.message).to.equal(timeoutErrorMessage);
           expect(error.isAxiosError).to.be.true;
+          expect(error.request.responseUrl).to.equal("/foo");
         }
       );
   });


### PR DESCRIPTION
Fixes #168

Adds the `request` object to the error. This is important and follows [the way that Axios handles errors](https://github.com/axios/axios#handling-errors).