### PR TITLE
Handle request with undefined url

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -33,13 +33,13 @@ function makeResponse(result, config) {
 }
 
 function handleRequest(mockAdapter, resolve, reject, config) {
-  var url = config.url;
+  var url = config.url || "";
   // TODO we're not hitting this `if` in any of the tests, investigate
   if (
     config.baseURL &&
-    config.url.substr(0, config.baseURL.length) === config.baseURL
+    url.substr(0, config.baseURL.length) === config.baseURL
   ) {
-    url = config.url.slice(config.baseURL.length);
+    url = url.slice(config.baseURL.length);
   }
 
   delete config.adapter;
@@ -120,7 +120,7 @@ function handleRequest(mockAdapter, resolve, reject, config) {
       case "passthrough":
         mockAdapter.originalAdapter(config).then(resolve, reject);
         break;
-      case 'throwException':
+      case "throwException":
         throw utils.createCouldNotFindMockError(config);
       default:
         utils.settle(

--- a/test/pass_through.spec.js
+++ b/test/pass_through.spec.js
@@ -121,6 +121,14 @@ describe("passThrough tests (requires Node)", function () {
     });
   });
 
+  it("handle request with baseURL only", function () {
+    mock.onAny().passThrough();
+
+    return instance.get(undefined).then(function (response) {
+      expect(response.data).to.equal("/");
+    });
+  });
+
   it("handles request transformations properly", function () {
     mock.onGet("/foo").passThrough();
 


### PR DESCRIPTION
I'm dealing with a 3rd party library that uses Axios and only defines `baseURL` without `url` for some reason. This results in an error because the request handler tries to call `substr` on `undefined`.

I simply added a fallback to an empty string for the `url` and added a test for it.
