### PR TITLE
Add onNoMatch: "throwException" to types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -24,7 +24,7 @@ export interface RequestHandler {
 
 interface MockAdapterOptions {
   delayResponse?: number;
-  onNoMatch?: 'passthrough';
+  onNoMatch?: 'passthrough' | 'throwException';
 }
 
 interface AsymmetricMatcher {


### PR DESCRIPTION
It looks like this was added as an option and included in the documentation but didn't get added to the types.