### PR TITLE
Clarify params usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ axios
   });
 ```
 
+When using `params`, you must match _all_ key/value pairs passed to that option.
+
 To add a delay to responses, specify a delay amount (in milliseconds) when instantiating the adapter
 
 ```js


### PR DESCRIPTION
When utilizing the `params` option in the mock handlers, it is unclear that you need to specify _all_ key/value pairs passed to that option. Based on the current docs, it can easily be misconstrued that only the key/value pairs that you pass to the mock handler are checked for equivalency.

This update adds an additional line to the README that clarifies this behavior.