### PR TITLE
fix responseURL case

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -27,7 +27,7 @@ function makeResponse(result, config) {
     headers: result[2],
     config: config,
     request: {
-      responseUrl: config.url,
+      responseURL: config.url,
     },
   };
 }

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -823,7 +823,7 @@ describe("MockAdapter basics", function () {
     });
   });
 
-  it("returns the original request url in the response.request.responseUrl property", function () {
+  it("returns the original request url in the response.request.responseURL property", function () {
     mock.onGet("/foo").reply(200, {
       foo: "bar",
     });
@@ -831,7 +831,7 @@ describe("MockAdapter basics", function () {
     return instance.get("/foo").then(function (response) {
       expect(response.status).to.equal(200);
       expect(response.data.foo).to.equal("bar");
-      expect(response.request.responseUrl).to.equal("/foo");
+      expect(response.request.responseURL).to.equal("/foo");
     });
   });
 


### PR DESCRIPTION
The case of `responseURL` is incorrect; "URL" is always uppercased. See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseURL .