### PR TITLE
Support for validateStatus: null

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -114,37 +114,39 @@ function purgeIfReplyOnce(mock, handler) {
 
 function settle(resolve, reject, response, delay) {
   if (delay > 0) {
-    setTimeout(function () {
-      settle(resolve, reject, response);
-    }, delay);
+    setTimeout(settle, delay, resolve, reject, response);
     return;
   }
 
-  if (response.config && response.config.validateStatus) {
+  // Support for axios < 0.13
+  if (!rejectWithError && (!response.config || !response.config.validateStatus)) {
+    if (response.status >= 200 && response.status < 300) {
+      resolve(response);
+    } else {
+      reject(response);
+    }
+    return;
+  }
+
+  if (
+    !response.config.validateStatus ||
     response.config.validateStatus(response.status)
-      ? resolve(response)
-      : reject(
-          createAxiosError(
-            "Request failed with status code " + response.status,
-            response.config,
-            response
-          )
-        );
-    return;
-  }
-
-  // Support for axios < 0.11
-  if (response.status >= 200 && response.status < 300) {
+  ) {
     resolve(response);
   } else {
-    reject(response);
+    if (!rejectWithError) {
+      return reject(response);
+    }
+
+    reject(createAxiosError(
+      'Request failed with status code ' + response.status,
+      response.config,
+      response
+    ));
   }
 }
 
 function createAxiosError(message, config, response, code) {
-  // Support for axios < 0.13.0
-  if (!rejectWithError) return response;
-
   var error = new Error(message);
   error.isAxiosError = true;
   error.config = config;

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -404,6 +404,15 @@ describe("MockAdapter basics", function () {
     });
   });
 
+  it("supports providing a validateStatus null value", function () {
+    instance.defaults.validateStatus = null;
+    mock.onGet("/foo").reply(500);
+
+    return instance.get("/foo").then(function (response) {
+      expect(response.status).to.equal(500);
+    });
+  });
+
   it("respects validatesStatus when requesting unhandled urls", function () {
     instance.defaults.validateStatus = function () {
       return true;


### PR DESCRIPTION
I've observed some issue where non-200 responses got rejected with an error object instead of an error instance. This was caused by the current `settle` implementation, which didn't support the `validateStatus` config completely.

I've also removed support for axios < 0.16 as all the tests were failing with it and it's not worth to fix them.
Axios 0.19 got released 5 years ago. Maybe we could also drop older versions as they aren't tested.

### Changelog
- Officially drop support for axios < 0.16 as most of the tests were failing
- Properly support `validateStatus: null` according to the documentation of axios