### PR TITLE
feat(hardening): ensure that an instance is provided to mock

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,6 @@ function resetHistory() {
 function MockAdapter(axiosInstance, options) {
   reset.call(this);
 
-  // TODO throw error instead when no axios instance is provided
   if (axiosInstance) {
     this.axiosInstance = axiosInstance;
     this.originalAdapter = axiosInstance.defaults.adapter;
@@ -60,6 +59,8 @@ function MockAdapter(axiosInstance, options) {
       options && options.delayResponse > 0 ? options.delayResponse : null;
     this.onNoMatch = (options && options.onNoMatch) || null;
     axiosInstance.defaults.adapter = this.adapter.call(this);
+  } else {
+    throw new Error("Please provide an instance of axios to mock");
   }
 }
 

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -17,6 +17,16 @@ describe("MockAdapter basics", function () {
     expect(instance.defaults.adapter).to.exist;
   });
 
+  it("correctly throws an error when attempting to instantiate an undefined axios instance", function () {
+    var emptyInstance = undefined;
+    var constructorFunc = function () {
+      new MockAdapter(emptyInstance);
+    };
+    expect(constructorFunc).to.throw(
+      "Please provide an instance of axios to mock"
+    );
+  });
+
   it("calls interceptors", function () {
     instance.interceptors.response.use(
       function (config) {


### PR DESCRIPTION
Hey there!  This is my first public PR so if I need to change anything please let me know!  I was using this library for a project and ran into an issue when we accidentally attempted to instantiate a mock instance against an empty import.  Hopefully this saves some folks some time in the future.

• Throw an error if there is no axios instance available to mock
• Test failing constructor