### PR TITLE
adds support for url params from url regexp capture groups

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -60,6 +60,10 @@ function handleRequest(mockAdapter, resolve, reject, config) {
       utils.purgeIfReplyOnce(mockAdapter, handler);
     }
 
+    if (handler[0] instanceof RegExp) {
+      config.urlParams = utils.getURLParams(handler[0], url, config.baseURL);
+    }
+
     if (handler.length === 2) {
       // passThrough handler
       mockAdapter.originalAdapter(config).then(resolve, reject);

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,6 +103,11 @@ function isBodyMatching(body, requiredBody) {
   return isObjectMatching(parsedBody ? parsedBody : body, requiredBody);
 }
 
+function getURLParams(matcher, url, baseURL) {
+  var matchResult = baseURL ? combineUrls(baseURL, url).match(matcher) : url.match(matcher);
+  return matchResult.groups || {};
+}
+
 function purgeIfReplyOnce(mock, handler) {
   Object.keys(mock.handlers).forEach(function (key) {
     var index = mock.handlers[key].indexOf(handler);
@@ -190,6 +195,7 @@ function createCouldNotFindMockError(config) {
 module.exports = {
   find: find,
   findHandler: findHandler,
+  getURLParams: getURLParams,
   purgeIfReplyOnce: purgeIfReplyOnce,
   settle: settle,
   isStream: isStream,

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -123,6 +123,17 @@ describe("MockAdapter basics", function () {
     });
   });
 
+  it("supports capture groups in urls with a regex", function () {
+    mock.onGet(/\/api\/foo\/(?<fooId>[^/]+)\/bar\/(?<barId>[^?/]+)$/).reply(function (config) {
+      return [200, config.urlParams];
+    });
+
+    return instance.get("/api/foo/1/bar/2").then(function (response) {
+      expect(response.data.fooId).to.equal('1');
+      expect(response.data.barId).to.equal('2');
+    });
+  });
+
   it("can pass query params for get to match to a handler", function () {
     mock
       .onGet("/withParams", { params: { foo: "bar", bar: "foo" } })


### PR DESCRIPTION
This PR adds support for url params taken from named capture groups of regex urls.

Below is an example of mocking a request to `/api/foo/1/bar/2` where we need some data from the url.
Before:
```js
mock.onGet(/\/api\/foo\/[^/]+\/bar\/[^?/]+$/).reply(function (config) {
  let { fooId, barId } = config.url.match(/\/api\/foo\/(?<fooId>[^/]+)\/bar\/(?<barId>[^?/]+)$/).groups;
  console.log(fooId, barId); // 1, 2
  return [200];
});
```
After:
```js
mock.onGet(/\/api\/foo\/(?<fooId>[^/]+)\/bar\/(?<barId>[^?/]+)$/).reply(function (config) {
  let { fooId, barId } = config.urlParams;
  console.log(fooId, barId); // 1, 2
  return [200];
});
```

This allows us to define the data we want from the url and to have it available in the reply function without having to duplicate the same (or similar) regex to extract the data.

## Notes
If there is anything that needs to be changed in this PR I am happy to do it.

This can be an alternative and an easy win for https://github.com/ctimmerm/axios-mock-adapter/pull/205.