### PR TITLE
Allow Blob Responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2282,6 +2282,11 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-blob": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+      "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw=="
+    },
     "is-buffer": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "fast-deep-equal": "^3.1.3",
+    "is-blob": "^2.1.0",
     "is-buffer": "^2.0.5"
   },
   "bundlesize": [

--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -6,7 +6,8 @@ function transformRequest(data) {
   if (
     utils.isArrayBuffer(data) ||
     utils.isBuffer(data) ||
-    utils.isStream(data)
+    utils.isStream(data) ||
+    utils.isBlob(data)
   ) {
     return data;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,7 @@
 var axios = require("axios");
 var isEqual = require("fast-deep-equal");
 var isBuffer = require("is-buffer");
+var isBlob = require("is-blob");
 var toString = Object.prototype.toString;
 
 // < 0.13.0 will not have default headers set on a custom instance
@@ -197,6 +198,7 @@ module.exports = {
   isFunction: isFunction,
   isObjectOrArray: isObjectOrArray,
   isBuffer: isBuffer,
+  isBlob: isBlob,
   isEqual: isEqual,
   createAxiosError: createAxiosError,
   createCouldNotFindMockError: createCouldNotFindMockError,

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -2,6 +2,7 @@ var expect = require("chai").expect;
 var find = require("../src/utils").find;
 var isEqual = require("../src/utils").isEqual;
 var isObjectOrArray = require("../src/utils").isObjectOrArray;
+var isBlob = require("../src/utils").isBlob;
 
 describe("utility functions", function () {
   context("find", function () {
@@ -61,6 +62,23 @@ describe("utility functions", function () {
       expect(isObjectOrArray("")).to.be.false;
       expect(isObjectOrArray(" ")).to.be.false;
       expect(isObjectOrArray("1")).to.be.false;
+    });
+  });
+
+  context("isBlob", function () {
+    it("returns false for anything that is not a Blob", function () {
+      expect(isBlob(true)).to.be.false;
+      expect(isBlob(false)).to.be.false;
+      expect(isBlob(null)).to.be.false;
+      expect(isBlob(undefined)).to.be.false;
+      expect(isBlob(function () {})).to.be.false;
+      expect(isBlob(0)).to.be.false;
+      expect(isBlob(1)).to.be.false;
+      expect(isBlob("")).to.be.false;
+      expect(isBlob(" ")).to.be.false;
+      expect(isBlob("1")).to.be.false;
+      expect(isBlob({ foo: "bar" })).to.be.false;
+      expect(isBlob([1, 2, 3])).to.be.false;
     });
   });
 });


### PR DESCRIPTION
This fixes #275, allowing to return Blob data in a response, and mocking any `AxiosRespones<Blob>` endpoint.

Added tests only for false-positive checking as Blob is not available in nodejs enviroment, to add missing test like 

```js
    it("returns true for Blob", function () {
      expect(isObjectOrArray(new Blob(['TEST BLOB'], { type: 'text/plain' }))).to.be.true;
    });
```

it would be necessary to install `cross-blob` lib, but I think it is out of the scope of this fix