### PR TITLE
rm url params when find handler

### DIFF
--- a/src/handle_request.js
+++ b/src/handle_request.js
@@ -43,13 +43,17 @@ function handleRequest(mockAdapter, resolve, reject, config) {
     url = url.slice(config.baseURL.length);
   }
 
+  if (url.indexOf("?") !== -1) {
+    url = url.substring(0, url.indexOf("?"))
+  }
+
   delete config.adapter;
   mockAdapter.history[config.method].push(config);
 
   var handler = utils.findHandler(
     mockAdapter.handlers,
     config.method,
-    url.substring(0,url.indexOf("?")),
+    url,
     config.data,
     config.params,
     config.headers,


### PR DESCRIPTION
var axios = require("axios");
var MockAdapter = require("axios-mock-adapter");
// This sets the mock adapter on the default instance
var mock = new MockAdapter(axios);

// Mock any GET request to /users
// arguments for reply are (status, data, headers)
mock.onGet("/users").reply(200, {
  users: [{id: 1, name: "John Smith"}],
});

axios.get("/users").then(function (response) {
  console.log(response.data);
});

### **// fix bug here. it will mismatch below**
axios.get("/users?req_id=xxxx").then(function (response) {
  console.log(response.data);
});

