### PR TITLE
Handle params and payloads on delete requests

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -77,8 +77,9 @@ function isUrlMatching(url, required) {
 function isBodyOrParametersMatching(method, body, parameters, required) {
   var allowedParamsMethods = ["delete", "get", "head", "options"];
   if (allowedParamsMethods.indexOf(method.toLowerCase()) >= 0) {
+    var data = required ? required.data : undefined;
     var params = required ? required.params : undefined;
-    return isObjectMatching(parameters, params);
+    return isObjectMatching(parameters, params) && isBodyMatching(body, data);
   } else {
     return isBodyMatching(body, required);
   }
@@ -206,6 +207,7 @@ module.exports = {
   isObjectOrArray: isObjectOrArray,
   isBuffer: isBuffer,
   isBlob: isBlob,
+  isBodyOrParametersMatching: isBodyOrParametersMatching,
   isEqual: isEqual,
   createAxiosError: createAxiosError,
   createCouldNotFindMockError: createCouldNotFindMockError,

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -157,6 +157,18 @@ describe("MockAdapter basics", function () {
       });
   });
 
+  it("can pass a body for delete to match to a handler", function () {
+    mock
+      .onDelete("/withParams",{ data: { bar: 2 }, params: { foo: 1 } })
+      .reply(200);
+
+    return instance
+      .delete("/withParams", { params: { foo: 1 }, data: { bar: 2 } } )
+      .then(function (response) {
+        expect(response.status).to.equal(200);
+      });
+  });
+
   it("can pass query params for head to match to a handler", function () {
     mock
       .onHead("/withParams", { params: { foo: "bar", bar: "foo" } })

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -3,6 +3,7 @@ var find = require("../src/utils").find;
 var isEqual = require("../src/utils").isEqual;
 var isObjectOrArray = require("../src/utils").isObjectOrArray;
 var isBlob = require("../src/utils").isBlob;
+var isBodyOrParametersMatching = require("../src/utils").isBodyOrParametersMatching;
 
 describe("utility functions", function () {
   context("find", function () {
@@ -79,6 +80,22 @@ describe("utility functions", function () {
       expect(isBlob("1")).to.be.false;
       expect(isBlob({ foo: "bar" })).to.be.false;
       expect(isBlob([1, 2, 3])).to.be.false;
+    });
+  });
+
+  context("isBodyOrParametersMatching", function() {
+    it('delete has params only', function () {
+      expect(isBodyOrParametersMatching('delete', null, { 'a': 2 }, { 'params': { 'a': 2 } } )).to.be.true;
+      expect(isBodyOrParametersMatching('delete', null, { 'a': 2 }, { 'params': { 'b': 2 } } )).to.be.false;
+    });
+    it('delete has data only', function () {
+      expect(isBodyOrParametersMatching('delete', { 'x': 1 }, null, { 'data': { 'x': 1 } })).to.be.true;
+      expect(isBodyOrParametersMatching('delete', { 'x': 1 }, null, { 'data': { 'y': 1 } })).to.be.false;
+    });
+    it('delete has body and params', function () {
+      expect(isBodyOrParametersMatching('delete', { 'x': 1 }, { 'a': 2 }, { 'data': { 'x': 1 }, 'params': { 'a': 2 } })).to.be.true;
+      expect(isBodyOrParametersMatching('delete', { 'x': 1 }, { 'a': 2 }, { 'data': { 'x': 1 }, 'params': { 'b': 2 } })).to.be.false;
+      expect(isBodyOrParametersMatching('delete', { 'x': 1 }, { 'a': 2 }, { 'data': { 'y': 1 }, 'params': { 'a': 2 } })).to.be.false;
     });
   });
 });


### PR DESCRIPTION
The `axios.delete` supports payloads since `0.21.0`: https://github.com/axios/axios/pull/3282