### PR TITLE
Fix regex in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,9 +253,9 @@ mock
 // Mock POST requests to /api with HTTP 201, but forward
 // GET requests to server
 mock
-  .onPost(/\/^api/)
+  .onPost(/^\/api/)
   .reply(201)
-  .onGet(/\/^api/)
+  .onGet(/^\/api/)
   .passThrough();
 ```
 


### PR DESCRIPTION
I'm surprised the existing regex even compiles but it looks like it does, and I guess it is technically a legal regex, it just will never match anything, because it requires the beginning of a string (or line) to come after a forward slash.

I'm assuming the intent was to match `/api` at the beginning of the path, so I've adjusted it accordingly.