### PR TITLE
added support for HTTP LINK and UNLINK

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@ var VERBS = [
   "put",
   "options",
   "list",
+  "link",
+  "unlink",
 ];
 
 function adapter() {

--- a/test/basics.spec.js
+++ b/test/basics.spec.js
@@ -55,6 +55,8 @@ describe("MockAdapter basics", function () {
     expect(mock.onPatch).to.be.a("function");
     expect(mock.onOptions).to.be.a("function");
     expect(mock.onList).to.be.a("function");
+    expect(mock.onLink).to.be.a("function");
+    expect(mock.onUnlink).to.be.a("function");
   });
 
   it("mocks requests", function () {

--- a/test/on_any.spec.js
+++ b/test/on_any.spec.js
@@ -16,8 +16,15 @@ describe("MockAdapter onAny", function () {
     mock.onAny("/foo").reply(200);
 
     expect(mock.handlers["get"]).not.to.be.empty;
+    expect(mock.handlers["post"]).not.to.be.empty;
+    expect(mock.handlers["head"]).not.to.be.empty;
+    expect(mock.handlers["delete"]).not.to.be.empty;
     expect(mock.handlers["patch"]).not.to.be.empty;
     expect(mock.handlers["put"]).not.to.be.empty;
+    expect(mock.handlers["options"]).not.to.be.empty;
+    expect(mock.handlers["list"]).not.to.be.empty;
+    expect(mock.handlers["link"]).not.to.be.empty;
+    expect(mock.handlers["unlink"]).not.to.be.empty;
   });
 
   it("mocks any request with a matching url", function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -73,6 +73,8 @@ declare class MockAdapter {
   onList: RequestMatcherFunc;
   onOptions: RequestMatcherFunc;
   onAny: RequestMatcherFunc;
+  onLink: RequestMatcherFunc;
+  onUnlink: RequestMatcherFunc;
 }
 
 export default MockAdapter;

--- a/types/test.ts
+++ b/types/test.ts
@@ -53,6 +53,8 @@ namespace SupportsAllHttpVerbs {
   mock.onDelete;
   mock.onPatch;
   mock.onList;
+  mock.onLink;
+  mock.onUnlink;
 }
 
 namespace SupportsAnyVerb {


### PR DESCRIPTION
A while ago I had to write tests that mock an external API that uses HTTP `LINK` and `UNLINK` methods. However there was no support in axios for these methods so I added it.
To proof that these methods are a thing here is a link to an [ietf.org document](https://datatracker.ietf.org/doc/html/draft-snell-link-method).