### PR TITLE
Use AxiosError constructor to create axios errors if available

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var axios = require("axios");
 var isEqual = require("fast-deep-equal");
 var isBuffer = require("is-buffer");
 var isBlob = require("./is_blob");
@@ -133,6 +134,12 @@ function settle(resolve, reject, response, delay) {
 }
 
 function createAxiosError(message, config, response, code) {
+  // axios v0.27.0+ defines AxiosError as constructor
+  if (typeof axios.AxiosError === 'function') {
+    return new axios.AxiosError(message, code, config, null, response);
+  }
+
+  // handling for axios v0.26.1 and below
   var error = new Error(message);
   error.isAxiosError = true;
   error.config = config;

--- a/src/utils.js
+++ b/src/utils.js
@@ -135,8 +135,8 @@ function settle(resolve, reject, response, delay) {
 
 function createAxiosError(message, config, response, code) {
   // axios v0.27.0+ defines AxiosError as constructor
-  if (typeof axios.AxiosError === 'function') {
-    return new axios.AxiosError(message, code, config, null, response);
+  if (typeof axios.AxiosError === "function") {
+    return axios.AxiosError.from(new Error(message), code, config, null, response);
   }
 
   // handling for axios v0.26.1 and below


### PR DESCRIPTION
From v0.27.2 axios uses a constructor to create instances of AxiosError. (See https://github.com/axios/axios/pull/3645). This PR uses said constructor to create errors and falls back to the previous behavior for older versions if the constructor is not available. This also fixes #338 