### PR TITLE
Throw ETIMEDOUT on timeout when clarifyTimeoutError is true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,9 @@ VERBS.concat("any").forEach(function (method) {
               "timeout of " + config.timeout + "ms exceeded",
             config,
             undefined,
-            "ECONNABORTED"
+            config.transitional?.clarifyTimeoutError
+              ? "ETIMEDOUT"
+              : "ECONNABORTED"
           );
           return Promise.reject(error);
         });
@@ -174,7 +176,9 @@ VERBS.concat("any").forEach(function (method) {
               "timeout of " + config.timeout + "ms exceeded",
             config,
             undefined,
-            "ECONNABORTED"
+            config.transitional?.clarifyTimeoutError
+              ? "ETIMEDOUT"
+              : "ECONNABORTED"
           );
           return Promise.reject(error);
         });

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ VERBS.concat("any").forEach(function (method) {
               "timeout of " + config.timeout + "ms exceeded",
             config,
             undefined,
-            config.transitional?.clarifyTimeoutError
+            config.transitional && config.transitional.clarifyTimeoutError
               ? "ETIMEDOUT"
               : "ECONNABORTED"
           );
@@ -176,7 +176,7 @@ VERBS.concat("any").forEach(function (method) {
               "timeout of " + config.timeout + "ms exceeded",
             config,
             undefined,
-            config.transitional?.clarifyTimeoutError
+            config.transitional && config.transitional.clarifyTimeoutError
               ? "ETIMEDOUT"
               : "ECONNABORTED"
           );


### PR DESCRIPTION
Fix bug where `timeout()` and `timeoutOnce()` would throw `ECONNABORTED`instead of the correct `ETIMEDOUT`, when `transitional.clarifyTimeoutError` was set to `true`.

Relevant Axios documentation:

```
    // throw ETIMEDOUT error instead of generic ECONNABORTED on request timeouts
    clarifyTimeoutError: false,
```

Source https://github.com/axios/axios/blob/v1.x/README.md#request-config.

Closes https://github.com/ctimmerm/axios-mock-adapter/issues/336.