### PR TITLE
Fix type exports

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,16 +10,18 @@ type ResponseSpecFunc = <T = any>(
   headers?: any
 ) => MockAdapter;
 
-export interface RequestHandler {
-  reply: ResponseSpecFunc;
-  replyOnce: ResponseSpecFunc;
-  passThrough(): MockAdapter;
-  abortRequest(): MockAdapter;
-  abortRequestOnce(): MockAdapter;
-  networkError(): MockAdapter;
-  networkErrorOnce(): MockAdapter;
-  timeout(): MockAdapter;
-  timeoutOnce(): MockAdapter;
+declare namespace MockAdapter {
+  export interface RequestHandler {
+    reply: ResponseSpecFunc;
+    replyOnce: ResponseSpecFunc;
+    passThrough(): MockAdapter;
+    abortRequest(): MockAdapter;
+    abortRequestOnce(): MockAdapter;
+    networkError(): MockAdapter;
+    networkErrorOnce(): MockAdapter;
+    timeout(): MockAdapter;
+    timeoutOnce(): MockAdapter;
+  }
 }
 
 interface MockAdapterOptions {
@@ -50,7 +52,7 @@ type RequestMatcherFunc = (
   matcher?: string | RegExp,
   body?: string | AsymmetricRequestDataMatcher,
   headers?: AsymmetricHeadersMatcher
-) => RequestHandler;
+) => AxiosAdapter.RequestHandler;
 
 declare class MockAdapter {
   constructor(axiosInstance: AxiosInstance, options?: MockAdapterOptions);
@@ -76,4 +78,4 @@ declare class MockAdapter {
   onUnlink: RequestMatcherFunc;
 }
 
-export default MockAdapter;
+export = MockAdapter;

--- a/types/test.ts
+++ b/types/test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import MockAdapter, { RequestHandler } from 'axios-mock-adapter';
+import MockAdapter = require('axios-mock-adapter');
 
 const instance = axios.create();
 const mock = new MockAdapter(instance);
@@ -149,6 +149,6 @@ namespace SupportsChaining {
 }
 
 namespace ExportsRequestHandlerInterface {
-  const handler: RequestHandler = mock.onAny();
+  const handler: MockAdapter.RequestHandler = mock.onAny();
   handler.reply(200);
 }


### PR DESCRIPTION
According to the old type definitions, this was correct usage:

```js
// CJS
const MockAdapter = require('axios-mock-adapter');

const mock = new MockAdapter.default(/* … */)
```

```js
// ESM
import MockAdapter from 'axios-mock-adapter';

const mock = new MockAdapter.default(/* … */)
```

With the updated type definitions, this is:

```js
// CJS
const MockAdapter = require('axios-mock-adapter');

const mock = new MockAdapter(/* … */)
```

```js
// ESM
import MockAdapter from 'axios-mock-adapter';

const mock = new MockAdapter(/* … */)
```

This has always been an issue, but it has become more apparent with the `"module": "node16"` option introduced in TypeScript 4.7.