### PR TITLE
Fix type error

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,7 +52,7 @@ type RequestMatcherFunc = (
   matcher?: string | RegExp,
   body?: string | AsymmetricRequestDataMatcher,
   headers?: AsymmetricHeadersMatcher
-) => AxiosAdapter.RequestHandler;
+) => MockAdapter.RequestHandler;
 
 declare class MockAdapter {
   constructor(axiosInstance: AxiosInstance, options?: MockAdapterOptions);


### PR DESCRIPTION
`RequestHandler` is part of the `MockAdapter` namespace, not `AxiosAdapter`.