### PR TITLE
Drop node versions lower than v18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
         axios-version: [0.17.0, latest]
         os: ['ubuntu-latest', 'macos-12']
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
@@ -40,7 +40,7 @@ jobs:
     - name: ESLint
       uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 22.x
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present


### PR DESCRIPTION
### Breaking Change 💥 
- Drop node versions lower than v18