### PR TITLE
Fix types for withDelayInMs

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,6 +12,7 @@ type ResponseSpecFunc = <T = any>(
 
 declare namespace MockAdapter {
   export interface RequestHandler {
+    withDelayInMs(delay: number): RequestHandler;
     reply: ResponseSpecFunc;
     replyOnce: ResponseSpecFunc;
     passThrough(): MockAdapter;

--- a/types/test.ts
+++ b/types/test.ts
@@ -125,6 +125,10 @@ namespace SupportsNetworkErrorOnce {
   mock.onGet().networkErrorOnce();
 }
 
+namespace withDelayInMs {
+  mock.onGet().withDelayInMs(2000).reply(200, { data: 'foo' });
+}
+
 namespace AllowsFunctionReply {
   mock.onGet().reply(config => {
     return [200, { data: 'foo' }, { RequestedURL: config.url }];


### PR DESCRIPTION
### Changelog
- 🚧 Fix types for `mock.onGet(url).withDelayInMs(delay).reply(code, data)`