### PR TITLE
Use responseURL from result.request

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -132,7 +132,7 @@ async function makeResponse(result, config) {
     data,
     headers,
     config,
-    request: { responseURL: config.url }
+    request: { responseURL: result.request?.responseURL || config.url },
   };
 }
 


### PR DESCRIPTION
If set, I want to be able to control the responseURL myself.
This is used to test certain scenarios where the request was redirected.